### PR TITLE
Make byte's non-constexpr operators inline

### DIFF
--- a/include/tao/json/byte.hpp
+++ b/include/tao/json/byte.hpp
@@ -58,7 +58,7 @@ namespace tao
          return byte( static_cast< unsigned char >( b ) >> shift );
       }
 
-      byte& operator|=( byte& l, byte r ) noexcept
+      inline byte& operator|=( byte& l, byte r ) noexcept
       {
          return l = byte( static_cast< unsigned char >( l ) | static_cast< unsigned char >( r ) );
       }
@@ -68,7 +68,7 @@ namespace tao
          return byte( static_cast< unsigned char >( l ) | static_cast< unsigned char >( r ) );
       }
 
-      byte& operator&=( byte& l, byte r ) noexcept
+      inline byte& operator&=( byte& l, byte r ) noexcept
       {
          return l = byte( static_cast< unsigned char >( l ) & static_cast< unsigned char >( r ) );
       }
@@ -78,7 +78,7 @@ namespace tao
          return byte( static_cast< unsigned char >( l ) & static_cast< unsigned char >( r ) );
       }
 
-      byte& operator^=( byte& l, byte r ) noexcept
+      inline byte& operator^=( byte& l, byte r ) noexcept
       {
          return l = byte( static_cast< unsigned char >( l ) ^ static_cast< unsigned char >( r ) );
       }


### PR DESCRIPTION
Fixes linking errors when using tao::json in multiple TUs