### PR TITLE
Support Conan

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,9 +1,5 @@
 version: '{branch}-{build}'
 
-branches:
-  only:
-    - master
-
 os:
 - Visual Studio 2015
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -34,9 +34,19 @@ environment:
 #      COMPILER: MinGW 6
 #      BINDIR: C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin
 
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      GENERATOR: Visual Studio 15 2017
+      CONAN_VISUAL_VERSIONS: 15
+      PYTHON: "C:\\Python27"
+      PYTHON_VERSION: "2.7.8"
+      PYTHON_ARCH: "32"
+      CONAN: TRUE
+
 init: []
 
-install: []
+install:
+- if defined CONAN (pip.exe install -U conan conan-package-tools)
+- if defined CONAN (conan profile new default --detect)
 
 before_build:
 - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" (del "C:\Program Files (x86)\MSBuild\14.0\Microsoft.Common.targets\ImportAfter\Xamarin.Common.targets")
@@ -50,3 +60,5 @@ build_script:
 
 test_script:
 - ctest -C "%CONFIGURATION%" --output-on-failure
+- if defined CONAN (cd ..)
+- if defined CONAN (python .conan/build.py)

--- a/.conan/build.py
+++ b/.conan/build.py
@@ -32,7 +32,7 @@ class BuilderSettings(object):
         ci_manager = CIManager(printer)
         branch = ci_manager.get_branch()
 
-        patterns = ["master$", self.stable_branch_pattern]
+        patterns = ["v?\d+\.\d+\.\d+-.*", self.stable_branch_pattern]
         for pattern in patterns:
             prog = re.compile(pattern)
             if branch and prog.match(branch):
@@ -50,7 +50,7 @@ class BuilderSettings(object):
     def stable_branch_pattern(self):
         """ Only upload the package the branch name is like a tag
         """
-        return os.getenv("CONAN_STABLE_BRANCH_PATTERN", r"\d+\.\d+\.\d+-?.*")
+        return os.getenv("CONAN_STABLE_BRANCH_PATTERN", r"v?\d+\.\d+\.\d+")
 
     @property
     def reference(self):

--- a/.conan/build.py
+++ b/.conan/build.py
@@ -4,6 +4,8 @@
 import os
 import re
 from cpt.packager import ConanMultiPackager
+from cpt.ci_manager import CIManager
+from cpt.printer import Printer
 
 
 class BuilderSettings(object):
@@ -15,16 +17,34 @@ class BuilderSettings(object):
 
     @property
     def upload(self):
-        """ Set taocpp repository to be used on upload
+        """ Set taocpp repository to be used on upload.
+            The upload server address could be customized by env var
+            CONAN_UPLOAD. If not defined, the method will check the branch name.
+            Only master or CONAN_STABLE_BRANCH_PATTERN will be accepted.
+            The master branch will be pushed to testing channel, because it does
+            not match the stable pattern. Otherwise it will upload to stable
+            channel.
         """
-        bintray_url = "https://api.bintray.com/conan/taocpp/public-conan"
-        return os.getenv("CONAN_UPLOAD", bintray_url)
+        if os.getenv("CONAN_UPLOAD", None) is not None:
+            return os.getenv("CONAN_UPLOAD")
+
+        printer = Printer(None)
+        ci_manager = CIManager(printer)
+        branch = ci_manager.get_branch()
+
+        patterns = ["master$", self.stable_branch_pattern]
+        for pattern in patterns:
+            prog = re.compile(pattern)
+            if branch and prog.match(branch):
+                return "https://api.bintray.com/conan/taocpp/public-conan"
+
+        return None
 
     @property
     def upload_only_when_stable(self):
-        """ Force to upload when running over tag branch
+        """ Force to upload when match stable pattern branch
         """
-        return os.getenv("CONAN_UPLOAD_ONLY_WHEN_STABLE", True)
+        return os.getenv("CONAN_UPLOAD_ONLY_WHEN_STABLE", False)
 
     @property
     def stable_branch_pattern(self):
@@ -45,7 +65,7 @@ class BuilderSettings(object):
                     version = result.group(1)
         if not version:
             raise Exception("Could not find version in CMakeLists.txt")
-        return os.getenv("CONAN_REFERENCE", "json/{}@taocpp/stable".format(version))
+        return os.getenv("CONAN_REFERENCE", "json/{}".format(version))
 
 if __name__ == "__main__":
     settings = BuilderSettings()

--- a/.conan/build.py
+++ b/.conan/build.py
@@ -30,7 +30,7 @@ class BuilderSettings(object):
     def stable_branch_pattern(self):
         """ Only upload the package the branch name is like a tag
         """
-        return os.getenv("CONAN_STABLE_BRANCH_PATTERN", r"\d+\.\d+\.\d+")
+        return os.getenv("CONAN_STABLE_BRANCH_PATTERN", r"\d+\.\d+\.\d+-?.*")
 
     @property
     def reference(self):

--- a/.conan/build.py
+++ b/.conan/build.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+import re
+from cpt.packager import ConanMultiPackager
+
+
+class BuilderSettings(object):
+    @property
+    def username(self):
+        """ Set taocpp as package's owner
+        """
+        return os.getenv("CONAN_USERNAME", "taocpp")
+
+    @property
+    def upload(self):
+        """ Set taocpp repository to be used on upload
+        """
+        bintray_url = "https://api.bintray.com/conan/taocpp/public-conan"
+        return os.getenv("CONAN_UPLOAD", bintray_url)
+
+    @property
+    def upload_only_when_stable(self):
+        """ Force to upload when running over tag branch
+        """
+        return os.getenv("CONAN_UPLOAD_ONLY_WHEN_STABLE", True)
+
+    @property
+    def stable_branch_pattern(self):
+        """ Only upload the package the branch name is like a tag
+        """
+        return os.getenv("CONAN_STABLE_BRANCH_PATTERN", r"\d+\.\d+\.\d+")
+
+    @property
+    def reference(self):
+        """ Read project version from CMake file to create Conan referece
+        """
+        pattern = re.compile(r"project \(taocpp-json VERSION (\d+\.\d+\.\d+) LANGUAGES CXX\)")
+        version = None
+        with open('CMakeLists.txt') as file:
+            for line in file:
+                result = pattern.match(line)
+                if result:
+                    version = result.group(1)
+        if not version:
+            raise Exception("Could not find version in CMakeLists.txt")
+        return os.getenv("CONAN_REFERENCE", "json/{}@taocpp/stable".format(version))
+
+if __name__ == "__main__":
+    settings = BuilderSettings()
+    builder = ConanMultiPackager(
+        reference=settings.reference,
+        username=settings.username,
+        upload=settings.upload,
+        upload_only_when_stable=settings.upload_only_when_stable,
+        stable_branch_pattern=settings.stable_branch_pattern,
+        test_folder=os.path.join(".conan", "test_package"))
+    builder.add()
+    builder.run()

--- a/.conan/build.py
+++ b/.conan/build.py
@@ -32,7 +32,7 @@ class BuilderSettings(object):
         ci_manager = CIManager(printer)
         branch = ci_manager.get_branch()
 
-        patterns = ["v?\d+\.\d+\.\d+-.*", self.stable_branch_pattern]
+        patterns = [r"v?\d+\.\d+\.\d+-.*", self.stable_branch_pattern]
         for pattern in patterns:
             prog = re.compile(pattern)
             if branch and prog.match(branch):

--- a/.conan/test_package/CMakeLists.txt
+++ b/.conan/test_package/CMakeLists.txt
@@ -9,4 +9,4 @@ conan_basic_setup()
 find_package(taocpp-json REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} taocpp::taocpp-json)
+target_link_libraries(${PROJECT_NAME} taocpp::json)

--- a/.conan/test_package/CMakeLists.txt
+++ b/.conan/test_package/CMakeLists.txt
@@ -1,0 +1,12 @@
+project(test_package CXX)
+cmake_minimum_required(VERSION 3.2.0 FATAL_ERROR)
+
+set(CMAKE_VERBOSE_MAKEFILE TRUE)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+find_package(taocpp-json REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} taocpp::taocpp-json)

--- a/.conan/test_package/conanfile.py
+++ b/.conan/test_package/conanfile.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from conans import ConanFile, CMake, tools, RunEnvironment
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        # Search for LICENSE file
+        path = os.path.join(self.deps_cpp_info["json"].rootpath, "licenses", "LICENSE")
+        assert os.path.isfile(path)
+        # Validate package import
+        with tools.environment_append(RunEnvironment(self).vars):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path)

--- a/.conan/test_package/test_package.cpp
+++ b/.conan/test_package/test_package.cpp
@@ -1,0 +1,16 @@
+// Copyright (c) 2014-2018 Dr. Colin Hirsch and Daniel Frey
+// Please see LICENSE for license or visit https://github.com/taocpp/json/
+
+#include <cstdlib>
+#include <iostream>
+
+#include <tao/json.hpp>
+
+int main()
+{
+   tao::json::value v;
+   v.emplace( "a", 1.0 );
+   v.emplace( "b", 2.0 );
+   tao::json::to_stream( std::cout, v );
+   return EXIT_SUCCESS;
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ language: generic
 os: linux
 dist: trusty
 
-branches:
-  only:
-    - master
-
 matrix:
   include:
     - compiler: gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -262,6 +262,20 @@ matrix:
       script:
         - python .conan/build.py
 
+    - compiler: gcc
+      addons:
+        apt:
+          sources: ['ubuntu-toolchain-r-test']
+          packages: ['g++-7']
+      env:
+        - CXX=g++-7
+      script:
+        - mkdir build
+        - cd build
+        - cmake ..
+        - cmake --build .
+        - cmake --build . --target test
+
 script:
   - $CXX --version
   - make -kj3

--- a/.travis.yml
+++ b/.travis.yml
@@ -250,6 +250,18 @@ matrix:
       script:
         - make -kj3 clang-tidy
 
+    - language: python
+      python:
+        - "3.6"
+      sudo: required
+      install:
+        - pip install conan conan-package-tools
+      env:
+        - CONAN_GCC_VERSIONS=7
+        - CONAN_DOCKER_IMAGE=lasote/conangcc7
+      script:
+        - python .conan/build.py
+
 script:
   - $CXX --version
   - make -kj3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,15 +8,15 @@ set (TAOCPP_JSON_INSTALL_DOC_DIR "share/doc/tao/json" CACHE STRING "The installa
 set (TAOCPP_JSON_INSTALL_CMAKE_DIR "share/taocpp-json/cmake" CACHE STRING "The installation cmake directory")
 
 # define a header-only library
-add_library (taocpp-json INTERFACE)
-add_library (taocpp::json ALIAS taocpp-json)
-target_include_directories (taocpp-json INTERFACE
+add_library (json INTERFACE)
+add_library (taocpp::json ALIAS json)
+target_include_directories (json INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:${TAOCPP_JSON_INSTALL_INCLUDE_DIR}>
 )
 
 # features used by taocpp/json
-target_compile_features (taocpp-json INTERFACE
+target_compile_features (json INTERFACE
   cxx_alias_templates
   cxx_auto_type
   cxx_constexpr
@@ -57,7 +57,7 @@ if (TAOCPP_JSON_BUILD_EXAMPLES)
 endif ()
 
 # install and export target
-install (TARGETS taocpp-json EXPORT taocpp-json-targets)
+install (TARGETS json EXPORT taocpp-json-targets)
 
 install (EXPORT taocpp-json-targets
   FILE taocpp-json-config.cmake

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # The Art of C++ / JSON
 
 [![Release](https://img.shields.io/github/release/taocpp/json.svg)](https://github.com/taocpp/json/releases/latest)
+[![Download](https://api.bintray.com/packages/taocpp/public-conan/json%3Ataocpp/images/download.svg) ](https://bintray.com/taocpp/public-conan/json%3Ataocpp/_latestVersion)
 [![TravisCI](https://travis-ci.org/taocpp/json.svg)](https://travis-ci.org/taocpp/json)
 [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/taocpp/json?svg=true)](https://ci.appveyor.com/project/taocpp/json)
 [![Coverage](https://img.shields.io/coveralls/taocpp/json.svg)](https://coveralls.io/github/taocpp/json)

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from conans import ConanFile, CMake
+
+class JSONConan(ConanFile):
+    name = "json"
+    description = "C++11 header-only JSON library "
+    homepage = "https://github.com/taocpp/json"
+    url = homepage
+    license = "MIT"
+    author = "taocpp@icemx.net"
+    settings = "compiler", "arch"
+    exports = "LICENSE"
+    exports_sources = "include/*", "CMakeLists.txt"
+    no_copy_source = True
+
+    def build(self):
+        pass
+
+    def package(self):
+        cmake = CMake(self)
+        cmake.definitions["TAOCPP_JSON_BUILD_TESTS"] = False
+        cmake.definitions["TAOCPP_JSON_BUILD_EXAMPLES"] = False
+        cmake.definitions["TAOCPP_JSON_INSTALL_DOC_DIR"] = "licenses"
+        cmake.configure()
+        cmake.install()
+
+    def package_id(self):
+        self.info.header_only()

--- a/src/example/json/CMakeLists.txt
+++ b/src/example/json/CMakeLists.txt
@@ -1,14 +1,37 @@
-file (GLOB examplesources *.cpp)
+cmake_minimum_required (VERSION 3.3.0 FATAL_ERROR)
+
+set (examplesources
+  config.cpp
+  validate_event_order.cpp
+  validate_integer.cpp
+)
+
+# file (GLOB ...) is used to validate the above list of example_sources
+file (GLOB glob_example_sources RELATIVE ${CMAKE_CURRENT_LIST_DIR} *.cpp)
+
 foreach (examplesourcefile ${examplesources})
+  if (${examplesourcefile} IN_LIST glob_example_sources)
+    list (REMOVE_ITEM glob_example_sources ${examplesourcefile})
+  else ()
+    message (SEND_ERROR "File ${examplesourcefile} is missing from src/example/json")
+  endif ()
   get_filename_component (exename ${examplesourcefile} NAME_WE)
   add_executable (${exename} ${examplesourcefile})
-  set_property (TARGET ${exename} PROPERTY CXX_STANDARD 11)
-  set_property (TARGET ${exename} PROPERTY CXX_STANDARD_REQUIRED ON)
-  set_property (TARGET ${exename} PROPERTY CXX_EXTENSIONS OFF)
-  target_link_libraries (${exename} taocpp::json)
+  target_link_libraries (${exename} PRIVATE taocpp::json)
+  set_target_properties (${exename} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED ON
+    CXX_EXTENSIONS OFF
+  )
   if (MSVC)
     target_compile_options (${exename} PRIVATE /W4 /WX /utf-8)
   else ()
     target_compile_options (${exename} PRIVATE -pedantic -Wall -Wextra -Wshadow -Werror)
   endif ()
 endforeach (examplesourcefile)
+
+if (glob_example_sources)
+  foreach (ignored_source_file ${glob_example_sources})
+    message (SEND_ERROR "File ${ignored_source_file} in src/example/json is ignored")
+  endforeach (ignored_source_file)
+endif ()

--- a/src/test/json/CMakeLists.txt
+++ b/src/test/json/CMakeLists.txt
@@ -1,11 +1,69 @@
-file (GLOB testsources *.cpp)
+cmake_minimum_required (VERSION 3.3.0 FATAL_ERROR)
+
+set(testsources
+  as.cpp
+  big_list_of_naughty_strings.cpp
+  binding.cpp
+  cbor.cpp
+  compare.cpp
+  composite_traits.cpp
+  create.cpp
+  double.cpp
+  dump_sizes.cpp
+  escape.cpp
+  events_compare.cpp
+  events_debug.cpp
+  events_hash.cpp
+  events_to_stream.cpp
+  events_to_string.cpp
+  include_json.cpp
+  index.cpp
+  integer.cpp
+  json_patch.cpp
+  json_pointer.cpp
+  key_camel_case_to_snake_case.cpp
+  key_snake_case_to_camel_case.cpp
+  literal.cpp
+  msgpack.cpp
+  object_operators.cpp
+  opaque.cpp
+  ostream.cpp
+  ostream_jaxn.cpp
+  parse.cpp
+  parse_jaxn.cpp
+  parsing.cpp
+  pointer.cpp
+  position.cpp
+  reference.cpp
+  schema.cpp
+  self_contained.cpp
+  sha256.cpp
+  string_view.cpp
+  traits.cpp
+  type.cpp
+  ubjson.cpp
+  uri_fragment.cpp
+  user.cpp
+  validate_event_interfaces.cpp
+)
+
+# file (GLOB ...) is used to validate the above list of test_sources
+file (GLOB glob_test_sources RELATIVE ${CMAKE_CURRENT_LIST_DIR} *.cpp)
+
 foreach (testsourcefile ${testsources})
+  if (${testsourcefile} IN_LIST glob_test_sources)
+    list (REMOVE_ITEM glob_test_sources ${testsourcefile})
+  else ()
+    message (SEND_ERROR "File ${testsourcefile} is missing from src/test/json")
+  endif ()
   get_filename_component (exename ${testsourcefile} NAME_WE)
   add_executable (${exename} ${testsourcefile})
-  set_property (TARGET ${exename} PROPERTY CXX_STANDARD 11)
-  set_property (TARGET ${exename} PROPERTY CXX_STANDARD_REQUIRED ON)
-  set_property (TARGET ${exename} PROPERTY CXX_EXTENSIONS OFF)
-  target_link_libraries (${exename} taocpp::json)
+  target_link_libraries (${exename} PRIVATE taocpp::json)
+  set_target_properties (${exename} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED ON
+    CXX_EXTENSIONS OFF
+  )
   if (MSVC)
     target_compile_options (${exename} PRIVATE /W4 /WX /utf-8)
   else ()
@@ -13,3 +71,9 @@ foreach (testsourcefile ${testsources})
   endif ()
   add_test (NAME ${exename} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../.. COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${exename})
 endforeach (testsourcefile)
+
+if (glob_test_sources)
+  foreach (ignored_source_file ${glob_test_sources})
+    message (SEND_ERROR "File ${ignored_source_file} in src/test/json is ignored")
+  endforeach (ignored_source_file)
+endif ()


### PR DESCRIPTION
Hi!

This PR brings the support to build taocpp-json as Conan package

What I included:

- Conan recipe as did for PEGTL and operators
- Run Conan package on Travis CI (linux) and Appveyor
- Add test package to validate the Conan package
- Add build.py to help Conan during CI stage

What should be done before to merge this branch:

- Set CONAN_LOGIN_USERNAME on Travis settings with `taocpp-user`
- Set CONAN_PASSWORD on Travis settings with taocpp-user API Key

/cc @pleroux0

Close #24