### PR TITLE
Fix windows (cl.exe) build

### DIFF
--- a/doc/Binding-Traits.md
+++ b/doc/Binding-Traits.md
@@ -159,7 +159,7 @@ Array bindings can "inherit" a base class' Array bindings, and Object bindings c
 
 By default, the Object traits' `to()` and `consume()` functions will throw an exception when they encounter an unknown Object key while converting a Value, or parsing some input, respectively.
 
-This can be changed by using `tao::json::binding::basic_object` instead of `tao::json::binding::object`, and passing `tao::json::binding::for_unknown_key::CONTINUE` as template parameter in the appropriate place (instead of `tao::json::binding::for_unknown_key::THROW`).
+This can be changed by using `tao::json::binding::basic_object` instead of `tao::json::binding::object`, and passing `tao::json::binding::for_unknown_key::skip` as template parameter in the appropriate place (instead of `tao::json::binding::for_unknown_key::fail`).
 
 With this change, unknown keys will be ignored.
 
@@ -167,7 +167,7 @@ With this change, unknown keys will be ignored.
 
 By default, the Object traits' `assign()` and `produce()` functions will encode all variables that it knows about, including those that might be considered "nothing".
 
-This can be changed by again using `tao::json::binding::basic_object` instead of `tao::json::binding::object`, and passing `tao::json::binding::for_nothing_value::SUPPRESS` as template parameter in the appropriate place (instead of `tao::json::binding::for_nothing_value::ENCODE`).
+This can be changed by again using `tao::json::binding::basic_object` instead of `tao::json::binding::object`, and passing `tao::json::binding::for_nothing_value::suppress` as template parameter in the appropriate place (instead of `tao::json::binding::for_nothing_value::ENCODE`).
 
 To determine whether something is to be considered "nothing", the Traits' optional `is_nothing()` function is used.
 

--- a/doc/Binding-Traits.md
+++ b/doc/Binding-Traits.md
@@ -138,7 +138,7 @@ This is even necessary to prevent collisions when there are two occurrences of t
 Constants works for Objects just like for Arrays, though of course a string with the key needs to be supplied in addition to the constant value.
 
 Constants are added to an Object binding with the macros `TAO_JSON_BIND_REQUIRED_BOOL()`, `TAO_JSON_BIND_REQUIRED_SIGNED()`, `TAO_JSON_BIND_REQUIRED_UNSIGNED()` and `TAO_JSON_BIND_REQUIRED_STRING()`.
-There are again variants with `OPTIONAL` in place of `REQUIRED` that are always encoded, but are not flagged as error when missing.
+There are again variants with `optional` in place of `required` that are always encoded, but are not flagged as error when missing.
 
 ```c++
 template< typename U, typename V >

--- a/include/tao/json/binding.hpp
+++ b/include/tao/json/binding.hpp
@@ -41,7 +41,7 @@ namespace tao
          using basic_object = internal::basic_object< E, N, json::internal::merge_type_lists< internal::inherit_members< As >... > >;
 
          template< typename... As >
-         using object = basic_object< for_unknown_key::THROW, for_nothing_value::ENCODE, As... >;
+         using object = basic_object< for_unknown_key::fail, for_nothing_value::encode, As... >;
 
       }  // namespace binding
 

--- a/include/tao/json/binding.hpp
+++ b/include/tao/json/binding.hpp
@@ -56,21 +56,21 @@ namespace tao
 #define TAO_JSON_BIND_ELEMENT_UNSIGNED( VaLue ) tao::json::binding::element_u< VaLue >
 #define TAO_JSON_BIND_ELEMENT_STRING( VaLue ) tao::json::binding::element_s< TAO_JSON_STRING_T( VaLue ) >
 
-#define TAO_JSON_BIND_REQUIRED( KeY, ... ) tao::json::binding::member< tao::json::binding::member_kind::REQUIRED, TAO_JSON_STRING_T( KeY ), __VA_ARGS__ >
-#define TAO_JSON_BIND_OPTIONAL( KeY, ... ) tao::json::binding::member< tao::json::binding::member_kind::OPTIONAL, TAO_JSON_STRING_T( KeY ), __VA_ARGS__ >
+#define TAO_JSON_BIND_REQUIRED( KeY, ... ) tao::json::binding::member< tao::json::binding::member_kind::required, TAO_JSON_STRING_T( KeY ), __VA_ARGS__ >
+#define TAO_JSON_BIND_OPTIONAL( KeY, ... ) tao::json::binding::member< tao::json::binding::member_kind::optional, TAO_JSON_STRING_T( KeY ), __VA_ARGS__ >
 
-#define TAO_JSON_BIND_REQUIRED_BOOL( KeY, VaLue ) tao::json::binding::member_b< tao::json::binding::member_kind::REQUIRED, TAO_JSON_STRING_T( KeY ), VaLue >
-#define TAO_JSON_BIND_REQUIRED_SIGNED( KeY, VaLue ) tao::json::binding::member_i< tao::json::binding::member_kind::REQUIRED, TAO_JSON_STRING_T( KeY ), VaLue >
-#define TAO_JSON_BIND_REQUIRED_UNSIGNED( KeY, VaLue ) tao::json::binding::member_u< tao::json::binding::member_kind::REQUIRED, TAO_JSON_STRING_T( KeY ), VaLue >
-#define TAO_JSON_BIND_REQUIRED_STRING( KeY, VaLue ) tao::json::binding::member_s< tao::json::binding::member_kind::REQUIRED, TAO_JSON_STRING_T( KeY ), TAO_JSON_STRING_T( VaLue ) >
+#define TAO_JSON_BIND_REQUIRED_BOOL( KeY, VaLue ) tao::json::binding::member_b< tao::json::binding::member_kind::required, TAO_JSON_STRING_T( KeY ), VaLue >
+#define TAO_JSON_BIND_REQUIRED_SIGNED( KeY, VaLue ) tao::json::binding::member_i< tao::json::binding::member_kind::required, TAO_JSON_STRING_T( KeY ), VaLue >
+#define TAO_JSON_BIND_REQUIRED_UNSIGNED( KeY, VaLue ) tao::json::binding::member_u< tao::json::binding::member_kind::required, TAO_JSON_STRING_T( KeY ), VaLue >
+#define TAO_JSON_BIND_REQUIRED_STRING( KeY, VaLue ) tao::json::binding::member_s< tao::json::binding::member_kind::required, TAO_JSON_STRING_T( KeY ), TAO_JSON_STRING_T( VaLue ) >
 
-#define TAO_JSON_BIND_OPTIONAL_BOOL( KeY, VaLue ) tao::json::binding::member_b< tao::json::binding::member_kind::OPTIONAL, TAO_JSON_STRING_T( KeY ), VaLue >
-#define TAO_JSON_BIND_OPTIONAL_SIGNED( KeY, VaLue ) tao::json::binding::member_i< tao::json::binding::member_kind::OPTIONAL, TAO_JSON_STRING_T( KeY ), VaLue >
-#define TAO_JSON_BIND_OPTIONAL_UNSIGNED( KeY, VaLue ) tao::json::binding::member_u< tao::json::binding::member_kind::OPTIONAL, TAO_JSON_STRING_T( KeY ), VaLue >
-#define TAO_JSON_BIND_OPTIONAL_STRING( KeY, VaLue ) tao::json::binding::member_s< tao::json::binding::member_kind::OPTIONAL, TAO_JSON_STRING_T( KeY ), TAO_JSON_STRING_T( VaLue ) >
+#define TAO_JSON_BIND_OPTIONAL_BOOL( KeY, VaLue ) tao::json::binding::member_b< tao::json::binding::member_kind::optional, TAO_JSON_STRING_T( KeY ), VaLue >
+#define TAO_JSON_BIND_OPTIONAL_SIGNED( KeY, VaLue ) tao::json::binding::member_i< tao::json::binding::member_kind::optional, TAO_JSON_STRING_T( KeY ), VaLue >
+#define TAO_JSON_BIND_OPTIONAL_UNSIGNED( KeY, VaLue ) tao::json::binding::member_u< tao::json::binding::member_kind::optional, TAO_JSON_STRING_T( KeY ), VaLue >
+#define TAO_JSON_BIND_OPTIONAL_STRING( KeY, VaLue ) tao::json::binding::member_s< tao::json::binding::member_kind::optional, TAO_JSON_STRING_T( KeY ), TAO_JSON_STRING_T( VaLue ) >
 
-#define TAO_JSON_BIND_REQUIRED1( ... ) tao::json::binding::member< tao::json::binding::member_kind::REQUIRED, tao::json::binding::internal::use_default_key, __VA_ARGS__ >
-#define TAO_JSON_BIND_OPTIONAL1( ... ) tao::json::binding::member< tao::json::binding::member_kind::OPTIONAL, tao::json::binding::internal::use_default_key, __VA_ARGS__ >
+#define TAO_JSON_BIND_REQUIRED1( ... ) tao::json::binding::member< tao::json::binding::member_kind::required, tao::json::binding::internal::use_default_key, __VA_ARGS__ >
+#define TAO_JSON_BIND_OPTIONAL1( ... ) tao::json::binding::member< tao::json::binding::member_kind::optional, tao::json::binding::internal::use_default_key, __VA_ARGS__ >
 
 #define TAO_JSON_FACTORY_BIND( KeY, ... ) tao::json::binding::internal::factory_temp< TAO_JSON_STRING_T( KeY ), __VA_ARGS__ >
 

--- a/include/tao/json/binding/for_nothing_value.hpp
+++ b/include/tao/json/binding/for_nothing_value.hpp
@@ -12,8 +12,8 @@ namespace tao
       {
          enum class for_nothing_value : bool
          {
-            ENCODE,
-            SUPPRESS
+            encode,
+            suppress
          };
 
       }  // namespace binding

--- a/include/tao/json/binding/for_unknown_key.hpp
+++ b/include/tao/json/binding/for_unknown_key.hpp
@@ -12,8 +12,8 @@ namespace tao
       {
          enum class for_unknown_key : bool
          {
-            THROW,
-            CONTINUE
+            fail,
+            skip
          };
 
       }  // namespace binding

--- a/include/tao/json/binding/internal/object.hpp
+++ b/include/tao/json/binding/internal/object.hpp
@@ -72,7 +72,7 @@ namespace tao
                template< typename A, std::size_t I >
                static void set_optional_bit( std::bitset< sizeof...( As ) >& t )
                {
-                  t.set( I, A::kind == member_kind::OPTIONAL );
+                  t.set( I, A::kind == member_kind::optional );
                }
 
                template< typename A, typename C, template< typename... > class Traits >

--- a/include/tao/json/binding/internal/object.hpp
+++ b/include/tao/json/binding/internal/object.hpp
@@ -109,7 +109,7 @@ namespace tao
                      const auto& k = p.first;
                      const auto i = m.find( k );
                      if( i == m.end() ) {
-                        if constexpr( E == for_unknown_key::CONTINUE ) {
+                        if constexpr( E == for_unknown_key::skip ) {
                            continue;
                         }
                         std::ostringstream oss;
@@ -124,7 +124,7 @@ namespace tao
                   b |= o;
                   if( !b.all() ) {
                      std::ostringstream oss;
-                     json::internal::format_to( oss, "missing required key(s)" );
+                     json::internal::format_to( oss, "missing requiredrequired key(s)" );
                      list_missing_keys( oss, b, m );
                      json::internal::format_to( oss, " for type ", typeid( C ), json::message_extension( v ) );
                      throw std::runtime_error( oss.str() );  // NOLINT
@@ -134,7 +134,7 @@ namespace tao
                template< typename A, template< typename... > class Traits, typename C >
                static void assign_member( basic_value< Traits >& v, const C& x )
                {
-                  if( ( N == for_nothing_value::ENCODE ) || ( !A::template is_nothing< Traits >( x ) ) ) {
+                  if( ( N == for_nothing_value::encode ) || ( !A::template is_nothing< Traits >( x ) ) ) {
                      v.unsafe_emplace( A::template key< Traits >(), A::read( x ) );
                   }
                }
@@ -180,7 +180,7 @@ namespace tao
                      const auto k = parser.key();
                      const auto i = m.find( k );
                      if( i == m.end() ) {
-                        if constexpr( E == for_unknown_key::CONTINUE ) {
+                        if constexpr( E == for_unknown_key::skip ) {
                            parser.skip_value();
                            continue;
                         }
@@ -209,7 +209,7 @@ namespace tao
                template< template< typename... > class Traits, typename C >
                static std::size_t produce_size( const C& x )
                {
-                  if constexpr( N == for_nothing_value::ENCODE ) {
+                  if constexpr( N == for_nothing_value::encode ) {
                      return sizeof...( As );
                   }
                   return ( std::size_t( !As::template is_nothing< Traits >( x ) ) + ... );
@@ -218,7 +218,7 @@ namespace tao
                template< typename A, template< typename... > class Traits, typename Consumer, typename C >
                static void produce_member( Consumer& consumer, const C& x )
                {
-                  if( ( N == for_nothing_value::ENCODE ) || ( !A::template is_nothing< Traits >( x ) ) ) {
+                  if( ( N == for_nothing_value::encode ) || ( !A::template is_nothing< Traits >( x ) ) ) {
                      A::template produce_key< Traits >( consumer );
                      A::template produce< Traits >( consumer, x );
                      consumer.member();
@@ -240,7 +240,7 @@ namespace tao
                   if( !A::template is_nothing< Traits >( x ) ) {
                      return a.at( A::template key< Traits >() ) == A::read( x );
                   }
-                  if constexpr( N == for_nothing_value::ENCODE ) {
+                  if constexpr( N == for_nothing_value::encode ) {
                      return a.at( A::template key< Traits >() ).is_null();
                   }
                   const auto i = a.find( A::template key< Traits >() );

--- a/include/tao/json/binding/member_kind.hpp
+++ b/include/tao/json/binding/member_kind.hpp
@@ -12,8 +12,8 @@ namespace tao
       {
          enum class member_kind : bool
          {
-            OPTIONAL,
-            REQUIRED
+            optional,
+            required
          };
 
       }  // namespace binding

--- a/include/tao/json/cbor/consume_file.hpp
+++ b/include/tao/json/cbor/consume_file.hpp
@@ -22,14 +22,14 @@ namespace tao
          template< typename T, template< typename... > class Traits = traits, typename F >
          T consume_file( F&& filename )
          {
-            cbor::basic_parts_parser< utf8_mode::CHECK, json_pegtl::file_input< json_pegtl::tracking_mode::lazy > > pp( std::forward< F >( filename ) );
+            cbor::basic_parts_parser< utf8_mode::check, json_pegtl::file_input< json_pegtl::tracking_mode::lazy > > pp( std::forward< F >( filename ) );
             return json::consume< T, Traits >( pp );
          }
 
          template< template< typename... > class Traits = traits, typename F, typename T >
          T consume_file( F&& filename, T& t )
          {
-            cbor::basic_parts_parser< utf8_mode::CHECK, json_pegtl::file_input< json_pegtl::tracking_mode::lazy > > pp( std::forward< F >( filename ) );
+            cbor::basic_parts_parser< utf8_mode::check, json_pegtl::file_input< json_pegtl::tracking_mode::lazy > > pp( std::forward< F >( filename ) );
             return json::consume< Traits >( pp, t );
          }
 

--- a/include/tao/json/cbor/consume_string.hpp
+++ b/include/tao/json/cbor/consume_string.hpp
@@ -20,14 +20,14 @@ namespace tao
          template< typename T, template< typename... > class Traits = traits, typename F >
          T consume_string( F&& string )
          {
-            cbor::basic_parts_parser< utf8_mode::CHECK, json_pegtl::memory_input< json_pegtl::tracking_mode::lazy, json_pegtl::eol::lf_crlf, const char* > > pp( string, __FUNCTION__ );
+            cbor::basic_parts_parser< utf8_mode::check, json_pegtl::memory_input< json_pegtl::tracking_mode::lazy, json_pegtl::eol::lf_crlf, const char* > > pp( string, __FUNCTION__ );
             return json::consume< T, Traits >( pp );
          }
 
          template< template< typename... > class Traits = traits, typename F, typename T >
          T consume_string( F&& string, T& t )
          {
-            cbor::basic_parts_parser< utf8_mode::CHECK, json_pegtl::memory_input< json_pegtl::tracking_mode::lazy, json_pegtl::eol::lf_crlf, const char* > > pp( string, __FUNCTION__ );
+            cbor::basic_parts_parser< utf8_mode::check, json_pegtl::memory_input< json_pegtl::tracking_mode::lazy, json_pegtl::eol::lf_crlf, const char* > > pp( string, __FUNCTION__ );
             return json::consume< Traits >( pp, t );
          }
 

--- a/include/tao/json/cbor/internal/grammar.hpp
+++ b/include/tao/json/cbor/internal/grammar.hpp
@@ -233,10 +233,10 @@ namespace tao
                static void parse_binary_unsafe( Input& in, Consumer& consumer )
                {
                   if( peek_minor_unsafe( in ) != minor_mask ) {
-                     consumer.binary( read_string_1< utf8_mode::TRUST, tao::binary_view >( in ) );
+                     consumer.binary( read_string_1< utf8_mode::trust, tao::binary_view >( in ) );
                   }
                   else {
-                     consumer.binary( read_string_n< utf8_mode::TRUST, std::vector< std::byte > >( in, major::BINARY ) );
+                     consumer.binary( read_string_n< utf8_mode::trust, std::vector< std::byte > >( in, major::BINARY ) );
                   }
                }
 
@@ -398,7 +398,7 @@ namespace tao
             {
             };
 
-            using grammar = basic_grammar< utf8_mode::CHECK >;
+            using grammar = basic_grammar< utf8_mode::check >;
 
          }  // namespace internal
 

--- a/include/tao/json/cbor/parts_parser.hpp
+++ b/include/tao/json/cbor/parts_parser.hpp
@@ -77,7 +77,7 @@ namespace tao
 
          }  // namespace internal
 
-         template< utf8_mode V = utf8_mode::CHECK, typename Input = json_pegtl::string_input< json_pegtl::tracking_mode::lazy > >
+         template< utf8_mode V = utf8_mode::check, typename Input = json_pegtl::string_input< json_pegtl::tracking_mode::lazy > >
          class basic_parts_parser
          {
          public:
@@ -133,7 +133,7 @@ namespace tao
 
             std::string binary()
             {
-               return string_impl< utf8_mode::TRUST, std::vector< std::byte > >( internal::major::BINARY, "expected binary" );
+               return string_impl< utf8_mode::trust, std::vector< std::byte > >( internal::major::BINARY, "expected binary" );
             }
 
             std::string key()
@@ -156,7 +156,7 @@ namespace tao
                if( b != std::uint8_t( internal::major::BINARY ) + internal::minor_mask ) {
                   throw json_pegtl::parse_error( "expected definitive binary", m_input );  // NOLINT
                }
-               return internal::read_string_1< utf8_mode::TRUST, tao::binary_view >( m_input );
+               return internal::read_string_1< utf8_mode::trust, tao::binary_view >( m_input );
             }
 
             std::string_view key_view()

--- a/include/tao/json/contrib/schema.hpp
+++ b/include/tao/json/contrib/schema.hpp
@@ -161,13 +161,13 @@ namespace tao
 
          enum class schema_format
          {
-            NONE,
-            DATE_TIME,
-            EMAIL,
-            HOSTNAME,
-            IPV4,
-            IPV6,
-            URI
+            none,
+            date_time,
+            email,
+            hostname,
+            ipv4,
+            ipv6,
+            uri
          };
 
          inline constexpr schema_flags operator|( const schema_flags lhs, const schema_flags rhs ) noexcept
@@ -225,8 +225,8 @@ namespace tao
             std::uint64_t m_min_properties;
             std::set< std::string > m_required;
 
-            schema_flags m_flags = schema_flags::NONE;
-            schema_format m_format = schema_format::NONE;
+            schema_flags m_flags = NONE;
+            schema_format m_format = schema_format::none;
 
             void add_type( const schema_flags v )
             {
@@ -560,22 +560,22 @@ namespace tao
                   }
                   const auto& s = p->unsafe_get_string();
                   if( s == "date-time" ) {
-                     m_format = schema_format::DATE_TIME;
+                     m_format = schema_format::date_time;
                   }
                   else if( s == "email" ) {
-                     m_format = schema_format::EMAIL;
+                     m_format = schema_format::email;
                   }
                   else if( s == "hostname" ) {
-                     m_format = schema_format::HOSTNAME;
+                     m_format = schema_format::hostname;
                   }
                   else if( s == "ipv4" ) {
-                     m_format = schema_format::IPV4;
+                     m_format = schema_format::ipv4;
                   }
                   else if( s == "ipv6" ) {
-                     m_format = schema_format::IPV6;
+                     m_format = schema_format::ipv6;
                   }
                   else if( s == "uri" ) {
-                     m_format = schema_format::URI;
+                     m_format = schema_format::uri;
                   }
                   // unknown "format" values are ignored
                }
@@ -1244,40 +1244,40 @@ namespace tao
                      m_match = false;
                   }
                }
-               if( m_match && m_node->m_format != schema_format::NONE ) {
+               if( m_match && m_node->m_format != schema_format::none ) {
                   switch( m_node->m_format ) {
-                     case schema_format::DATE_TIME:
+                     case schema_format::date_time:
                         if( !internal::parse_date_time( v ) ) {
                            m_match = false;
                         }
                         break;
-                     case schema_format::EMAIL:
+                     case schema_format::email:
                         if( ( v.size() > 255 ) || !internal::parse< internal::email >( v ) ) {
                            m_match = false;
                         }
                         break;
-                     case schema_format::HOSTNAME:
+                     case schema_format::hostname:
                         if( ( v.size() > 255 ) || !internal::parse< internal::hostname >( v ) ) {
                            m_match = false;
                         }
                         break;
-                     case schema_format::IPV4:
+                     case schema_format::ipv4:
                         if( !internal::parse< json_pegtl::uri::IPv4address >( v ) ) {
                            m_match = false;
                         }
                         break;
-                     case schema_format::IPV6:
+                     case schema_format::ipv6:
                         if( !internal::parse< json_pegtl::uri::IPv6address >( v ) ) {
                            m_match = false;
                         }
                         break;
-                     case schema_format::URI:
+                     case schema_format::uri:
                         // TODO: What rule exactly should we apply here?? JSON Schema is not exactly the best spec I've ever read...
                         if( !internal::parse< json_pegtl::uri::URI >( v ) ) {
                            m_match = false;
                         }
                         break;
-                     case schema_format::NONE:;
+                     case schema_format::none:;
                   }
                }
             }

--- a/include/tao/json/msgpack/consume_file.hpp
+++ b/include/tao/json/msgpack/consume_file.hpp
@@ -22,14 +22,14 @@ namespace tao
          template< typename T, template< typename... > class Traits = traits, typename F >
          T consume_file( F&& filename )
          {
-            msgpack::basic_parts_parser< utf8_mode::CHECK, json_pegtl::file_input< json_pegtl::tracking_mode::lazy > > pp( std::forward< F >( filename ) );
+            msgpack::basic_parts_parser< utf8_mode::check, json_pegtl::file_input< json_pegtl::tracking_mode::lazy > > pp( std::forward< F >( filename ) );
             return json::consume< T, Traits >( pp );
          }
 
          template< template< typename... > class Traits = traits, typename F, typename T >
          T consume_file( F&& filename, T& t )
          {
-            msgpack::basic_parts_parser< utf8_mode::CHECK, json_pegtl::file_input< json_pegtl::tracking_mode::lazy > > pp( std::forward< F >( filename ) );
+            msgpack::basic_parts_parser< utf8_mode::check, json_pegtl::file_input< json_pegtl::tracking_mode::lazy > > pp( std::forward< F >( filename ) );
             return json::consume< Traits >( pp, t );
          }
 

--- a/include/tao/json/msgpack/consume_string.hpp
+++ b/include/tao/json/msgpack/consume_string.hpp
@@ -20,14 +20,14 @@ namespace tao
          template< typename T, template< typename... > class Traits = traits, typename F >
          T consume_string( F&& string )
          {
-            msgpack::basic_parts_parser< utf8_mode::CHECK, json_pegtl::memory_input< json_pegtl::tracking_mode::lazy, json_pegtl::eol::lf_crlf, const char* > > pp( string, __FUNCTION__ );
+            msgpack::basic_parts_parser< utf8_mode::check, json_pegtl::memory_input< json_pegtl::tracking_mode::lazy, json_pegtl::eol::lf_crlf, const char* > > pp( string, __FUNCTION__ );
             return json::consume< T, Traits >( pp );
          }
 
          template< template< typename... > class Traits = traits, typename F, typename T >
          T consume_string( F&& string, T& t )
          {
-            msgpack::basic_parts_parser< utf8_mode::CHECK, json_pegtl::memory_input< json_pegtl::tracking_mode::lazy, json_pegtl::eol::lf_crlf, const char* > > pp( string, __FUNCTION__ );
+            msgpack::basic_parts_parser< utf8_mode::check, json_pegtl::memory_input< json_pegtl::tracking_mode::lazy, json_pegtl::eol::lf_crlf, const char* > > pp( string, __FUNCTION__ );
             return json::consume< Traits >( pp, t );
          }
 

--- a/include/tao/json/msgpack/internal/grammar.hpp
+++ b/include/tao/json/msgpack/internal/grammar.hpp
@@ -110,13 +110,13 @@ namespace tao
                         in.bump_in_this_line();
                         return;
                      case format::BIN8:
-                        consumer.binary( json::internal::read_string< utf8_mode::TRUST, tao::binary_view >( in, json::internal::read_big_endian_number< std::size_t, std::uint8_t >( in, 1 ) ) );
+                        consumer.binary( json::internal::read_string< utf8_mode::trust, tao::binary_view >( in, json::internal::read_big_endian_number< std::size_t, std::uint8_t >( in, 1 ) ) );
                         return;
                      case format::BIN16:
-                        consumer.binary( json::internal::read_string< utf8_mode::TRUST, tao::binary_view >( in, json::internal::read_big_endian_number< std::size_t, std::uint16_t >( in, 1 ) ) );
+                        consumer.binary( json::internal::read_string< utf8_mode::trust, tao::binary_view >( in, json::internal::read_big_endian_number< std::size_t, std::uint16_t >( in, 1 ) ) );
                         return;
                      case format::BIN32:
-                        consumer.binary( json::internal::read_string< utf8_mode::TRUST, tao::binary_view >( in, json::internal::read_big_endian_number< std::size_t, std::uint32_t >( in, 1 ) ) );
+                        consumer.binary( json::internal::read_string< utf8_mode::trust, tao::binary_view >( in, json::internal::read_big_endian_number< std::size_t, std::uint32_t >( in, 1 ) ) );
                         return;
                      case format::EXT8:
                         discard( in, json::internal::read_big_endian_number< std::size_t, std::uint8_t >( in, 1 ) + 1 );
@@ -238,7 +238,7 @@ namespace tao
             {
             };
 
-            using grammar = basic_grammar< utf8_mode::CHECK >;
+            using grammar = basic_grammar< utf8_mode::check >;
 
          }  // namespace internal
 

--- a/include/tao/json/msgpack/parts_parser.hpp
+++ b/include/tao/json/msgpack/parts_parser.hpp
@@ -48,11 +48,11 @@ namespace tao
             {
                switch( peek_format( in ) ) {
                   case format::BIN8:
-                     return json::internal::read_string< utf8_mode::TRUST, tao::binary_view >( in, json::internal::read_big_endian_number< std::size_t, std::uint8_t >( in, 1 ) );
+                     return json::internal::read_string< utf8_mode::trust, tao::binary_view >( in, json::internal::read_big_endian_number< std::size_t, std::uint8_t >( in, 1 ) );
                   case format::BIN16:
-                     return json::internal::read_string< utf8_mode::TRUST, tao::binary_view >( in, json::internal::read_big_endian_number< std::size_t, std::uint16_t >( in, 1 ) );
+                     return json::internal::read_string< utf8_mode::trust, tao::binary_view >( in, json::internal::read_big_endian_number< std::size_t, std::uint16_t >( in, 1 ) );
                   case format::BIN32:
-                     return json::internal::read_string< utf8_mode::TRUST, tao::binary_view >( in, json::internal::read_big_endian_number< std::size_t, std::uint32_t >( in, 1 ) );
+                     return json::internal::read_string< utf8_mode::trust, tao::binary_view >( in, json::internal::read_big_endian_number< std::size_t, std::uint32_t >( in, 1 ) );
                   default:
                      throw json_pegtl::parse_error( "expected binary data", in );  // NOLINT
                }
@@ -171,7 +171,7 @@ namespace tao
 
          }  // namespace internal
 
-         template< utf8_mode V = utf8_mode::CHECK, typename Input = json_pegtl::string_input< json_pegtl::tracking_mode::lazy > >
+         template< utf8_mode V = utf8_mode::check, typename Input = json_pegtl::string_input< json_pegtl::tracking_mode::lazy > >
          class basic_parts_parser
          {
          public:

--- a/include/tao/json/ubjson/consume_file.hpp
+++ b/include/tao/json/ubjson/consume_file.hpp
@@ -22,14 +22,14 @@ namespace tao
          template< typename T, template< typename... > class Traits = traits, typename F >
          T consume_file( F&& filename )
          {
-            ubjson::basic_parts_parser< 1 << 24, utf8_mode::CHECK, json_pegtl::file_input< json_pegtl::tracking_mode::lazy > > pp( std::forward< F >( filename ) );
+            ubjson::basic_parts_parser< 1 << 24, utf8_mode::check, json_pegtl::file_input< json_pegtl::tracking_mode::lazy > > pp( std::forward< F >( filename ) );
             return json::consume< T, Traits >( pp );
          }
 
          template< template< typename... > class Traits = traits, typename F, typename T >
          T consume_file( F&& filename, T& t )
          {
-            ubjson::basic_parts_parser< 1 << 24, utf8_mode::CHECK, json_pegtl::file_input< json_pegtl::tracking_mode::lazy > > pp( std::forward< F >( filename ) );
+            ubjson::basic_parts_parser< 1 << 24, utf8_mode::check, json_pegtl::file_input< json_pegtl::tracking_mode::lazy > > pp( std::forward< F >( filename ) );
             return json::consume< Traits >( pp, t );
          }
 

--- a/include/tao/json/ubjson/consume_string.hpp
+++ b/include/tao/json/ubjson/consume_string.hpp
@@ -20,14 +20,14 @@ namespace tao
          template< typename T, template< typename... > class Traits = traits, typename F >
          T consume_string( F&& string )
          {
-            ubjson::basic_parts_parser< 1 << 24, utf8_mode::CHECK, json_pegtl::memory_input< json_pegtl::tracking_mode::lazy, json_pegtl::eol::lf_crlf, const char* > > pp( string, __FUNCTION__ );
+            ubjson::basic_parts_parser< 1 << 24, utf8_mode::check, json_pegtl::memory_input< json_pegtl::tracking_mode::lazy, json_pegtl::eol::lf_crlf, const char* > > pp( string, __FUNCTION__ );
             return json::consume< T, Traits >( pp );
          }
 
          template< template< typename... > class Traits = traits, typename F, typename T >
          T consume_string( F&& string, T& t )
          {
-            ubjson::basic_parts_parser< 1 << 24, utf8_mode::CHECK, json_pegtl::memory_input< json_pegtl::tracking_mode::lazy, json_pegtl::eol::lf_crlf, const char* > > pp( string, __FUNCTION__ );
+            ubjson::basic_parts_parser< 1 << 24, utf8_mode::check, json_pegtl::memory_input< json_pegtl::tracking_mode::lazy, json_pegtl::eol::lf_crlf, const char* > > pp( string, __FUNCTION__ );
             return json::consume< Traits >( pp, t );
          }
 

--- a/include/tao/json/ubjson/internal/grammar.hpp
+++ b/include/tao/json/ubjson/internal/grammar.hpp
@@ -297,7 +297,7 @@ namespace tao
                   }
                   if( c == marker::UINT8 ) {
                      // NOTE: UBJSON encodes binary data as 'strongly typed array of uint8 values'.
-                     consumer.binary( read_string< L, utf8_mode::TRUST, tao::binary_view >( in ) );
+                     consumer.binary( read_string< L, utf8_mode::trust, tao::binary_view >( in ) );
                      return;
                   }
                   const auto size = read_size< L >( in );
@@ -398,7 +398,7 @@ namespace tao
             {
             };
 
-            using grammar = basic_grammar< 1 << 24, utf8_mode::CHECK >;
+            using grammar = basic_grammar< 1 << 24, utf8_mode::check >;
 
          }  // namespace internal
 

--- a/include/tao/json/ubjson/parts_parser.hpp
+++ b/include/tao/json/ubjson/parts_parser.hpp
@@ -115,7 +115,7 @@ namespace tao
 
          }  // namespace internal
 
-         template< std::size_t L, utf8_mode V = utf8_mode::CHECK, typename Input = json_pegtl::string_input< json_pegtl::tracking_mode::lazy > >
+         template< std::size_t L, utf8_mode V = utf8_mode::check, typename Input = json_pegtl::string_input< json_pegtl::tracking_mode::lazy > >
          class basic_parts_parser
          {
          public:
@@ -165,7 +165,7 @@ namespace tao
                check_marker( internal::marker::UINT8, "expected type uint8 for array for binary" );
                check_marker( internal::marker::CONTAINER_SIZE, "expected sized array for binary" );
                const auto size = internal::read_size< L >( m_input );
-               return json::internal::read_string< utf8_mode::TRUST, tao::binary_view >( m_input, size );
+               return json::internal::read_string< utf8_mode::trust, tao::binary_view >( m_input, size );
             }
 
             std::string_view key()

--- a/include/tao/json/utf8.hpp
+++ b/include/tao/json/utf8.hpp
@@ -15,8 +15,8 @@ namespace tao
    {
       enum class utf8_mode : bool
       {
-         CHECK,
-         TRUST
+         check,
+         trust
       };
 
       namespace internal
@@ -28,7 +28,7 @@ namespace tao
          };
 
          template< typename Input >
-         void consume_utf8_impl( Input& in, const utf8_todo< utf8_mode::CHECK > todo )
+         void consume_utf8_impl( Input& in, const utf8_todo< utf8_mode::check > todo )
          {
             std::size_t i = 0;
             while( i < todo.todo ) {
@@ -41,7 +41,7 @@ namespace tao
          }
 
          template< typename Input >
-         void consume_utf8_impl( Input& in, const utf8_todo< utf8_mode::TRUST > todo )
+         void consume_utf8_impl( Input& in, const utf8_todo< utf8_mode::trust > todo )
          {
             in.bump_in_this_line( todo.todo );
          }

--- a/src/test/json/binding_object.cpp
+++ b/src/test/json/binding_object.cpp
@@ -84,7 +84,7 @@ namespace tao
          TEST_ASSERT( a.z.second == 6 );
          value w = v;
          w[ "s" ] = "";
-         w[ "d" ] = null;  // Must compare equal without this entry when using for_nothing_value::SUPPRESS.
+         w[ "d" ] = null;  // Must compare equal without this entry when using for_nothing_value::suppress.
          TEST_ASSERT( a == w );
          TEST_ASSERT( w == a );
          TEST_ASSERT( !( a != w ) );

--- a/src/test/json/temporary_parsing.cpp
+++ b/src/test/json/temporary_parsing.cpp
@@ -176,8 +176,8 @@ namespace tao
 
       template<>
       struct my_traits< test_suppress >
-         : binding::basic_object< binding::for_unknown_key::CONTINUE,
-                                  binding::for_nothing_value::SUPPRESS,
+         : binding::basic_object< binding::for_unknown_key::skip,
+                                  binding::for_nothing_value::suppress,
                                   TAO_JSON_BIND_OPTIONAL( "list", &test_suppress::list ) >
       {
       };


### PR DESCRIPTION
tao::json::binding::member_kind::OPTIONAL is conflicting with Windows define OPTIONAL, defined in minwindef.h which is imported automatically when importing iostream, causing build errors.

1st suggested commit does #undef OPTIONAL, which basically fixes the problem
2nd commit changes OPTIONAL to lowercase, eliminating the need of #undef
3rd commit brings most of used enum class to lowercase for consistency.
