### PR TITLE
Use transparent comparator for object_t map

### DIFF
--- a/include/tao/json/basic_value.hpp
+++ b/include/tao/json/basic_value.hpp
@@ -44,7 +44,7 @@ namespace tao::json
       static_assert( std::is_nothrow_move_assignable_v< public_base_t > );
 
       using array_t = std::vector< basic_value >;
-      using object_t = std::map< std::string, basic_value >;
+      using object_t = std::map< std::string, basic_value, std::less<> >;
 
       basic_value() noexcept = default;
 

--- a/include/tao/json/binding/factory.hpp
+++ b/include/tao/json/binding/factory.hpp
@@ -116,7 +116,7 @@ namespace tao::json::binding
       using as_func_t = Pointer< Base > ( * )( const basic_value< Traits >&, With&... );
 
       template< typename V, template< typename... > class Traits, template< typename... > class Pointer, typename Base, typename... With >
-      static void emplace_as( std::map< std::string, entry1< as_func_t< Traits, Pointer, Base, With... > > >& m )
+      static void emplace_as( std::map< std::string, entry1< as_func_t< Traits, Pointer, Base, With... > >, std::less<> >& m )
       {
          using W = typename V::template bind< Base, Pointer >;
          m.emplace( W::template key< Traits >(), entry1< as_func_t< Traits, Pointer, Base, With... > >( &W::template as< Traits, With... > ) );
@@ -125,8 +125,8 @@ namespace tao::json::binding
       template< template< typename... > class Traits, template< typename... > class Pointer, typename Base, typename... With >
       static void to( const basic_value< Traits >& v, Pointer< Base >& r, With&... with )
       {
-         static const std::map< std::string, entry1< as_func_t< Traits, Pointer, Base, With... > > > m = []() {
-            std::map< std::string, entry1< as_func_t< Traits, Pointer, Base, With... > > > t;
+         static const std::map< std::string, entry1< as_func_t< Traits, Pointer, Base, With... > >, std::less<> > m = []() {
+            std::map< std::string, entry1< as_func_t< Traits, Pointer, Base, With... > >, std::less<> > t;
             ( emplace_as< Ts >( t ), ... );
             assert( t.size() == sizeof...( Ts ) );
             return t;
@@ -181,7 +181,7 @@ namespace tao::json::binding
       }
 
       template< typename V, template< typename... > class Traits, template< typename... > class Pointer, typename Base, typename Producer, typename F >
-      static void emplace_consume( std::map< std::string, entry1< F > >& m )
+      static void emplace_consume( std::map< std::string, entry1< F >, std::less<> >& m )
       {
          using W = typename V::template bind< Base, Pointer >;
          m.emplace( W::template key< Traits >(), entry1< F >( &W::template consume< Traits, Producer > ) );
@@ -191,8 +191,8 @@ namespace tao::json::binding
       static void consume( Producer& parser, Pointer< Base >& r )
       {
          using F = Pointer< Base > ( * )( Producer& );
-         static const std::map< std::string, entry1< F > > m = []() {
-            std::map< std::string, entry1< F > > t;
+         static const std::map< std::string, entry1< F >, std::less<> > m = []() {
+            std::map< std::string, entry1< F >, std::less<> > t;
             ( emplace_consume< Ts, Traits, Pointer, Base, Producer >( t ), ... );
             return t;
          }();

--- a/include/tao/json/binding/internal/object.hpp
+++ b/include/tao/json/binding/internal/object.hpp
@@ -75,7 +75,7 @@ namespace tao::json::binding::internal
       }
 
       template< typename A, std::size_t I, typename C, template< typename... > class Traits, typename F >
-      static void emplace_to( std::map< std::string, entry< F > >& m )
+      static void emplace_to( std::map< std::string, entry< F >, std::less<> >& m )
       {
          m.emplace( A::template key< Traits >(), entry< F >( &basic_object::to_wrapper< A, C, Traits >, I ) );
       }
@@ -84,8 +84,8 @@ namespace tao::json::binding::internal
       static void to( const basic_value< Traits >& v, C& x )
       {
          using F = void ( * )( const basic_value< Traits >&, C& );
-         static const std::map< std::string, entry< F > > m = []() {
-            std::map< std::string, entry< F > > t;
+         static const std::map< std::string, entry< F >, std::less<> > m = []() {
+            std::map< std::string, entry< F >, std::less<> > t;
             ( emplace_to< As, Is, C, Traits >( t ), ... );
             assert( t.size() == sizeof...( As ) );  // TODO: Check for duplicate keys at compile time?
             return t;
@@ -153,7 +153,7 @@ namespace tao::json::binding::internal
       }
 
       template< typename A, std::size_t I, typename C, template< typename... > class Traits, typename Producer, typename F >
-      static void emplace_consume( std::map< std::string, entry< F > >& m )
+      static void emplace_consume( std::map< std::string, entry< F >, std::less<> >& m )
       {
          m.emplace( A::template key< Traits >(), entry< F >( &basic_object::consume_wrapper< A, C, Traits, Producer >, I ) );
       }
@@ -162,8 +162,8 @@ namespace tao::json::binding::internal
       static void consume( Producer& parser, C& x )
       {
          using F = void ( * )( Producer&, C& );
-         static const std::map< std::string, entry< F > > m = []() {
-            std::map< std::string, entry< F > > t;
+         static const std::map< std::string, entry< F >, std::less<> > m = []() {
+            std::map< std::string, entry< F >, std::less<> > t;
             ( emplace_consume< As, Is, C, Traits, Producer >( t ), ... );
             assert( t.size() == sizeof...( As ) );  // TODO: Check for duplicate keys at compile time?
             return t;
@@ -235,7 +235,7 @@ namespace tao::json::binding::internal
       }
 
       template< typename A, template< typename... > class Traits, typename C >
-      [[nodiscard]] static bool equal_member( const std::map< std::string, basic_value< Traits > >& a, C& x )
+      [[nodiscard]] static bool equal_member( const std::map< std::string, basic_value< Traits >, std::less<> >& a, C& x )
       {
          if( !A::template is_nothing< Traits >( x ) ) {
             return a.at( A::template key< Traits >() ) == A::read( x );

--- a/include/tao/json/internal/value_union.hpp
+++ b/include/tao/json/internal/value_union.hpp
@@ -50,7 +50,7 @@ namespace tao::json::internal
       tao::binary_view xv;
 
       std::vector< T > a;
-      std::map< std::string, T > o;
+      std::map< std::string, T, std::less<> > o;
 
       const T* p;
       opaque_ptr_t q;

--- a/include/tao/json/traits.hpp
+++ b/include/tao/json/traits.hpp
@@ -793,20 +793,20 @@ namespace tao::json
    };
 
    template< template< typename... > class Traits >
-   struct traits< std::map< std::string, basic_value< Traits > > >
+   struct traits< std::map< std::string, basic_value< Traits >, std::less<> > >
    {
-      static void assign( basic_value< Traits >& v, const std::map< std::string, basic_value< Traits > >& o )
+      static void assign( basic_value< Traits >& v, const std::map< std::string, basic_value< Traits >, std::less<> >& o )
       {
          v.unsafe_assign_object( std::move( o ) );
       }
 
-      static void assign( basic_value< Traits >& v, std::map< std::string, basic_value< Traits > >&& o ) noexcept
+      static void assign( basic_value< Traits >& v, std::map< std::string, basic_value< Traits >, std::less<> >&& o ) noexcept
       {
          v.unsafe_assign_object( std::move( o ) );
       }
 
       template< template< typename... > class, typename Consumer >
-      static void produce( Consumer& c, const std::map< std::string, basic_value< Traits > >& o )
+      static void produce( Consumer& c, const std::map< std::string, basic_value< Traits >, std::less<> >& o )
       {
          c.begin_object( o.size() );
          for( const auto& i : o ) {
@@ -818,7 +818,7 @@ namespace tao::json
       }
 
       template< template< typename... > class, typename Consumer >
-      static void produce( Consumer& c, std::map< std::string, basic_value< Traits > >&& o )
+      static void produce( Consumer& c, std::map< std::string, basic_value< Traits >, std::less<> >&& o )
       {
          c.begin_object( o.size() );
          for( auto&& i : o ) {

--- a/src/test/json/binding_factory.cpp
+++ b/src/test/json/binding_factory.cpp
@@ -242,7 +242,7 @@ namespace tao::json
       arg_dummy d;
 
       const auto v = from_string( "{ \"foo\" : { \"nine\" : 1 }, \"bar\" : { \"eight\" : 2 } }" );
-      const auto a = v.as_with< std::map< std::string, std::shared_ptr< base_2 > > >( d );
+      const auto a = v.as_with< std::map< std::string, std::shared_ptr< base_2 >, std::less<> > >( d );
       TEST_ASSERT( a.size() == 2 );
       TEST_ASSERT( std::dynamic_pointer_cast< derived_9 >( a.at( "foo" ) ) );
       TEST_ASSERT( std::dynamic_pointer_cast< derived_8 >( a.at( "bar" ) ) );

--- a/src/test/json/contrib_traits.cpp
+++ b/src/test/json/contrib_traits.cpp
@@ -126,7 +126,7 @@ namespace tao::json
 
    void test_map()
    {
-      const std::map< std::string, std::uint64_t > f = { { "a", 1 }, { "b", 2 }, { "c", 3 } };
+      const std::map< std::string, std::uint64_t, std::less<> > f = { { "a", 1 }, { "b", 2 }, { "c", 3 } };
       value v = f;
       TEST_ASSERT( v == f );
       TEST_ASSERT( v.is_object() );
@@ -134,10 +134,10 @@ namespace tao::json
       TEST_ASSERT( v[ "a" ] == 1 );
       TEST_ASSERT( v[ "b" ] == 2 );
       TEST_ASSERT( v[ "c" ] == 3 );
-      const auto g = v.as< std::map< std::string, std::uint64_t > >();
+      const auto g = v.as< std::map< std::string, std::uint64_t, std::less<> > >();
       TEST_ASSERT( g == f );
 
-      const std::map< std::string, std::uint64_t > h = { { "a", 1 }, { "b", 3 }, { "c", 1 } };
+      const std::map< std::string, std::uint64_t, std::less<> > h = { { "a", 1 }, { "b", 3 }, { "c", 1 } };
       TEST_ASSERT( h != v );
       TEST_ASSERT( h > v );
       TEST_ASSERT( h >= v );
@@ -151,7 +151,7 @@ namespace tao::json
       TEST_ASSERT( !( v >= h ) );
       TEST_ASSERT( !( v == h ) );
 
-      const std::map< std::string, std::uint64_t > i = { { "a", 1 }, { "c", 2 }, { "d", 0 } };
+      const std::map< std::string, std::uint64_t, std::less<> > i = { { "a", 1 }, { "c", 2 }, { "d", 0 } };
       TEST_ASSERT( i != v );
       TEST_ASSERT( i > v );
       TEST_ASSERT( i >= v );

--- a/src/test/json/create.cpp
+++ b/src/test/json/create.cpp
@@ -495,7 +495,7 @@ namespace tao::json
          TEST_ASSERT( v.type() == type::DOUBLE );
          TEST_ASSERT( std::isnan( v.get_double() ) );
 
-         v = std::map< std::string, value >();
+         v = std::map< std::string, value, std::less<> >();
 
          TEST_ASSERT( v.type() == type::OBJECT );
          TEST_ASSERT( v.get_object().empty() );
@@ -518,7 +518,7 @@ namespace tao::json
       test_empty_array( std::vector< value >() );
 
       test_empty_object( empty_object );
-      test_empty_object( std::map< std::string, value >() );
+      test_empty_object( std::map< std::string, value, std::less<> >() );
 
       test_array_1234();
       test_object_1234();

--- a/src/test/json/dump_sizes.cpp
+++ b/src/test/json/dump_sizes.cpp
@@ -23,7 +23,7 @@ namespace tao::json
       std::cout << "std::vector< json::value >: " << sizeof( std::vector< value > ) << std::endl;
       std::cout << "std::list< json::value >: " << sizeof( std::list< value > ) << std::endl;
 
-      std::cout << "std::map< std::string, json::value >: " << sizeof( std::map< std::string, value > ) << std::endl;
+      std::cout << "std::map< std::string, json::value, std::less<> >: " << sizeof( std::map< std::string, value, std::less<> > ) << std::endl;
       std::cout << "std::multimap< std::string, json::value >: " << sizeof( std::multimap< std::string, value > ) << std::endl;
       std::cout << "std::unordered_map< std::string, json::value >: " << sizeof( std::unordered_map< std::string, value > ) << std::endl;
       std::cout << "std::unordered_multimap< std::string, json::value >: " << sizeof( std::unordered_multimap< std::string, value > ) << std::endl;

--- a/src/test/json/temporary_parsing.cpp
+++ b/src/test/json/temporary_parsing.cpp
@@ -278,7 +278,7 @@ namespace tao::json
       }
       {
          parts_parser pp( " { \"a\" : 4, \"b\" : 5 } ", __FUNCTION__ );
-         const auto v = consume< std::map< std::string, int >, my_traits >( pp );
+         const auto v = consume< std::map< std::string, int, std::less<> >, my_traits >( pp );
          TEST_ASSERT( v.size() == 2 );
          TEST_ASSERT( v.at( "a" ) == 4 );
          TEST_ASSERT( v.at( "b" ) == 5 );


### PR DESCRIPTION
Use a transparent comparator in the object map to support lookups with std::string_view. Supported since c++14.