### PR TITLE
Adapt options when built as sub-project

### DIFF
--- a/.cmake/taocpp-json-config.cmake.in
+++ b/.cmake/taocpp-json-config.cmake.in
@@ -1,4 +1,6 @@
-# When a dependency is added with add_subdirectory, but searched with find_package
+@PACKAGE_INIT@
 
-# Redirect to the directory added with add_subdirectory
-add_subdirectory("@PROJECT_SOURCE_DIR@" "@PROJECT_BINARY_DIR@")
+include(CMakeFindDependencyMacro)
+find_dependency(pegtl @PEGTL_MIN_VERSION@ CONFIG)
+
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,32 +1,42 @@
-cmake_minimum_required(VERSION 3.8.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.8...3.19)
 
 project(taocpp-json VERSION 1.0.0 LANGUAGES CXX)
 
+# Determine if taocpp-json is built as a subproject (using add_subdirectory)
+# or if it is the master project.
+set(MASTER_PROJECT OFF)
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+  set(MASTER_PROJECT ON)
+endif()
+
+
 # installation directories
-set(TAOCPP_JSON_INSTALL_INCLUDE_DIR "include" CACHE STRING "The installation include directory")
-set(TAOCPP_JSON_INSTALL_DOC_DIR "share/doc/tao/json" CACHE STRING "The installation doc directory")
-set(TAOCPP_JSON_INSTALL_CMAKE_DIR "share/taocpp-json/cmake" CACHE STRING "The installation cmake directory")
+include(GNUInstallDirs)
+
+set(TAOCPP_JSON_INSTALL_DOC_DIR "${CMAKE_INSTALL_DOCDIR}/tao/json" CACHE STRING "The installation doc directory")
+set(TAOCPP_JSON_INSTALL_CMAKE_DIR "${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake" CACHE STRING "The installation cmake directory")
 
 # define a header-only library
 add_library(json INTERFACE)
 add_library(taocpp::json ALIAS json)
 target_include_directories(json INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:${TAOCPP_JSON_INSTALL_INCLUDE_DIR}>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
 # require C++17
 target_compile_features(json INTERFACE cxx_std_17)
 
 # find a suitable PEGTL
-find_package(pegtl 3.1.0 QUIET CONFIG)
+set(PEGTL_MIN_VERSION 3.1.0)
+find_package(pegtl ${PEGTL_MIN_VERSION} QUIET CONFIG)
 if(NOT pegtl_FOUND)
   # if a compatible version of PEGTL is not already installed, build and install it from the submodule directory
   message(STATUS "Adding PEGTL as submodule from external/PEGTL.")
   set(PEGTL_BUILD_TESTS OFF CACHE BOOL "Disable PEGTL tests")
   set(PEGTL_BUILD_EXAMPLES OFF CACHE BOOL "Disable PEGTL examples")
-  set(PEGTL_INSTALL_INCLUDE_DIR ${TAOCPP_JSON_INSTALL_INCLUDE_DIR} CACHE STRING "Override PEGTL include install directory")
-  set(PEGTL_INSTALL_CMAKE_DIR ${TAOCPP_JSON_INSTALL_CMAKE_DIR}/pegtl CACHE STRING "Override PEGTL cmake install directory")
+  set(PEGTL_INSTALL_INCLUDE_DIR ${CMAKE_INSTALL_INCLUDEDIR} CACHE STRING "Override PEGTL include install directory")
+  set(PEGTL_INSTALL_CMAKE_DIR ${CMAKE_INSTALL_DATAROOTDIR}/pegtl/cmake CACHE STRING "Override PEGTL cmake install directory")
   add_subdirectory(external/PEGTL)
 endif()
 
@@ -34,32 +44,47 @@ endif()
 target_link_libraries(json INTERFACE taocpp::pegtl)
 
 # testing
-option(TAOCPP_JSON_BUILD_TESTS "Build test programs" ON)
+option(TAOCPP_JSON_BUILD_TESTS "Build test programs" ${MASTER_PROJECT})
 if(TAOCPP_JSON_BUILD_TESTS)
   enable_testing()
   add_subdirectory(src/test/json)
 endif()
 
 # examples
-option(TAOCPP_JSON_BUILD_EXAMPLES "Build example programs" ON)
+option(TAOCPP_JSON_BUILD_EXAMPLES "Build example programs" ${MASTER_PROJECT})
 if(TAOCPP_JSON_BUILD_EXAMPLES)
   add_subdirectory(src/example/json)
 endif()
 
-# Make package findable
-configure_file(.cmake/taocpp-json-config.cmake.in taocpp-json-config.cmake @ONLY)
+option(TAOCPP_JSON_INSTALL "Generate the install target" ${MASTER_PROJECT})
+if(TAOCPP_JSON_INSTALL)
+  include(CMakePackageConfigHelpers)
 
-# Ignore pointer width differences since this is a header-only library
-unset(CMAKE_SIZEOF_VOID_P)
+  # Make package findable
+  configure_package_config_file(.cmake/taocpp-json-config.cmake.in ${PROJECT_NAME}-config.cmake
+    INSTALL_DESTINATION ${TAOCPP_JSON_INSTALL_CMAKE_DIR}
+    NO_CHECK_REQUIRED_COMPONENTS_MACRO
+    NO_SET_AND_CHECK_MACRO
+  )
 
-# install and export target
-install(TARGETS json EXPORT taocpp-json-targets)
+  # Ignore pointer width differences since this is a header-only library
+  unset(CMAKE_SIZEOF_VOID_P)
 
-install(EXPORT taocpp-json-targets
-  FILE taocpp-json-config.cmake
-  NAMESPACE taocpp::
-  DESTINATION ${TAOCPP_JSON_INSTALL_CMAKE_DIR}
-)
+  # Enable version checks in find_package
+  write_basic_package_version_file(${PROJECT_NAME}-config-version.cmake COMPATIBILITY SameMajorVersion)
 
-install(DIRECTORY include/ DESTINATION ${TAOCPP_JSON_INSTALL_INCLUDE_DIR})
-install(FILES LICENSE DESTINATION ${TAOCPP_JSON_INSTALL_DOC_DIR})
+  # install and export target
+  install(TARGETS json EXPORT ${PROJECT_NAME}-targets)
+  install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
+    DESTINATION ${TAOCPP_JSON_INSTALL_CMAKE_DIR}
+  )
+  install(EXPORT ${PROJECT_NAME}-targets
+    NAMESPACE taocpp::
+    DESTINATION ${TAOCPP_JSON_INSTALL_CMAKE_DIR}
+  )
+
+  install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+  install(FILES LICENSE DESTINATION ${TAOCPP_JSON_INSTALL_DOC_DIR})
+endif()


### PR DESCRIPTION
skipp tests, example, and install targets

this fix https://github.com/taocpp/json/issues/94