### PR TITLE
Fix bug in array_traits::to

### DIFF
--- a/include/tao/json/contrib/array_traits.hpp
+++ b/include/tao/json/contrib/array_traits.hpp
@@ -22,7 +22,7 @@ namespace tao::json
       {
          const auto& a = v.get_array();
          for( std::size_t i = 0; i < N; ++i ) {
-            v.to_with( r[ i ], with... );
+            a[i].to_with(r[i], with...);
          }
       }
 

--- a/src/test/json/contrib_traits.cpp
+++ b/src/test/json/contrib_traits.cpp
@@ -180,6 +180,40 @@ namespace tao::json
       TEST_ASSERT( !( v == h ) );
    }
 
+   void test_array()
+   {
+      const std::array< std::uint64_t, 4 > f = { 1, 2, 3, 4 };
+      value v = f;
+      TEST_ASSERT( v == f );
+      TEST_ASSERT( v >= f );
+      TEST_ASSERT( v <= f );
+      TEST_ASSERT( f == v );
+      TEST_ASSERT( f >= v );
+      TEST_ASSERT( f <= v );
+      TEST_ASSERT( v.is_array() );
+      TEST_ASSERT( v.get_array().size() == 4 );
+      TEST_ASSERT( v[ 0 ] == 1 );
+      TEST_ASSERT( v[ 1 ] == 2 );
+      TEST_ASSERT( v[ 2 ] == 3 );
+      TEST_ASSERT( v[ 3 ] == 4 );
+      const auto g = v.as< std::array< std::uint64_t, 4 > >();
+      TEST_ASSERT( g == f );
+
+      const std::array< std::uint64_t, 3 > h = { 2, 3, 4 };
+      TEST_ASSERT( h != v );
+      TEST_ASSERT( h > v );
+      TEST_ASSERT( h >= v );
+      TEST_ASSERT( !( h < v ) );
+      TEST_ASSERT( !( h <= v ) );
+      TEST_ASSERT( !( h == v ) );
+      TEST_ASSERT( v != h );
+      TEST_ASSERT( v < h );
+      TEST_ASSERT( v <= h );
+      TEST_ASSERT( !( v > h ) );
+      TEST_ASSERT( !( v >= h ) );
+      TEST_ASSERT( !( v == h ) );
+   }
+
    void test_map()
    {
       const std::map< std::string, std::uint64_t, std::less<> > f = { { "a", 1 }, { "b", 2 }, { "c", 3 } };
@@ -255,6 +289,7 @@ namespace tao::json
       test_list();
       test_set();
       test_vector();
+      test_array();
       test_map();
 
       test_pointer();


### PR DESCRIPTION
array_traits::to causes std::logic_error exception to be thrown when converting array elements. I have added a test which triggers the bug and also the fix.