### PR TITLE
Fix workflow failure for older Xcode on macOS

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,10 +15,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        xcode: ['11', '12', '13']
-        build_type: [Debug, Release]
-
-    runs-on: macos-latest
+        include:
+          - xcode: 11
+            build_type: Debug
+            os: macos-11
+          - xcode: 11
+            build_type: Release
+            os: macos-11
+          - xcode: 12
+            build_type: Debug
+            os: macos-11
+          - xcode: 12
+            build_type: Release
+            os: macos-11
+          - xcode: 13
+            build_type: Debug
+            os: macos-12
+          - xcode: 13
+            build_type: Release
+            os: macos-12
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Currently, some of the macOS build jobs are failing (see e. g. https://github.com/taocpp/json/actions/runs/3881440807/jobs/6620448550). The reason is that certain versions of Xcode are only available on certain versions of the macOS image.

Xcode 11 and Xcode 12 are only available on the macOS 11 runner image, so we have to use the older image for those jobs. Xcode 13 jobs can be run on macOS 12. (Currently, `macos-latest` is the same as `macos-12`, see https://github.blog/changelog/2022-10-03-github-actions-jobs-running-on-macos-latest-are-now-running-on-macos-12/.)