### PR TITLE
Sped up parsing by ~0..40%-ish

### DIFF
--- a/include/tao/json/events/set_value.hpp
+++ b/include/tao/json/events/set_value.hpp
@@ -34,12 +34,16 @@ namespace tao::json::events
          InPlaceVector() {}
          ~InPlaceVector()
          {
-            std::destroy_n( array, std::min( count, count_ ) );
+            std::destroy_n( array, size() );
          }
          void emplace_back( basic_value< Traits >&& v )
          {
             ::new( array + count ) basic_value< Traits >{ std::move( v ) };
             ++count;
+         }
+         size_t size() const
+         {
+            return std::min( count, count_ );
          }
       };
       std::vector< basic_value< Traits > > stack_;
@@ -138,8 +142,7 @@ namespace tao::json::events
          auto& a = stack_.back().get_array();
          if( elements.count == count_ ) {
             a.reserve( count_ + 1 );
-            for( auto& i : elements.array )
-               a.push_back( std::move( i ) );
+            a.resize( count_ );
             ++elements.count;
          }
          a.push_back( std::move( value_ ) );
@@ -149,9 +152,19 @@ namespace tao::json::events
       {
          auto& elements = elements_.back();
          auto& v = stack_.back();
-         if( elements.count <= count_ )
-            v.get_array().assign( std::make_move_iterator( elements.array ),
-                                  std::make_move_iterator( elements.array + elements.count ) );
+         if( elements.count ) {
+            const auto size = elements.size();
+            auto& a = v.get_array();
+            if( a.empty() ) {
+               a.assign( std::make_move_iterator( elements.array ),
+                         std::make_move_iterator( elements.array + size ) );
+            }
+            else {
+               std::copy_n( std::make_move_iterator( elements.array ),
+                            size,
+                            a.begin() );
+            }
+         }
          value_ = std::move( v );
          stack_.pop_back();
          elements_.pop_back();

--- a/include/tao/json/events/set_value.hpp
+++ b/include/tao/json/events/set_value.hpp
@@ -6,6 +6,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <deque>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -22,14 +23,27 @@ namespace tao::json::events
    template< template< typename... > class Traits >
    struct set_basic_value
    {
-      static constexpr size_t count_ = 4;
-      struct ArrayElements
+      static constexpr size_t count_ = 42;
+      struct InPlaceVector
       {
-         basic_value< Traits > array[ count_ ];
+         union
+         {
+            basic_value< Traits > array[ count_ ];
+         };
          size_t count = 0;
+         InPlaceVector() {}
+         ~InPlaceVector()
+         {
+            std::destroy_n( array, std::min( count, count_ ) );
+         }
+         void emplace_back( basic_value< Traits >&& v )
+         {
+            ::new( array + count ) basic_value< Traits >{ std::move( v ) };
+            ++count;
+         }
       };
       std::vector< basic_value< Traits > > stack_;
-      std::vector< ArrayElements > elements_;
+      std::deque< InPlaceVector > elements_;
       std::vector< std::string > keys_;
       basic_value< Traits >& value_;
 
@@ -118,8 +132,7 @@ namespace tao::json::events
       {
          auto& elements = elements_.back();
          if( elements.count < count_ ) {
-            elements.array[ elements.count ] = std::move( value_ );
-            ++elements.count;
+            elements.emplace_back( std::move( value_ ) );
             return;
          }
          auto& a = stack_.back().get_array();

--- a/include/tao/json/events/set_value.hpp
+++ b/include/tao/json/events/set_value.hpp
@@ -24,6 +24,7 @@ namespace tao::json::events
    struct set_basic_value
    {
       static constexpr size_t count_ = 42;
+      static constexpr size_t count_skip_bit_ = size_t{ 1 } << ( std::numeric_limits< size_t >::digits - 1 );
       struct InPlaceVector
       {
          union
@@ -43,7 +44,7 @@ namespace tao::json::events
          }
          size_t size() const
          {
-            return std::min( count, count_ );
+            return count & ~count_skip_bit_;
          }
       };
       std::vector< basic_value< Traits > > stack_;
@@ -128,7 +129,7 @@ namespace tao::json::events
       void begin_array( const std::size_t size )
       {
          begin_array();
-         elements_.back().count = count_ + 1;
+         elements_.back().count |= count_skip_bit_;
          stack_.back().get_array().reserve( size );
       }
 
@@ -143,7 +144,7 @@ namespace tao::json::events
          if( elements.count == count_ ) {
             a.reserve( count_ + 1 );
             a.resize( count_ );
-            ++elements.count;
+            elements.count |= count_skip_bit_;
          }
          a.push_back( std::move( value_ ) );
       }
@@ -152,8 +153,7 @@ namespace tao::json::events
       {
          auto& elements = elements_.back();
          auto& v = stack_.back();
-         if( elements.count ) {
-            const auto size = elements.size();
+         if( const size_t size = elements.size() ) {
             auto& a = v.get_array();
             if( a.empty() ) {
                a.assign( std::make_move_iterator( elements.array ),


### PR DESCRIPTION
# Disclaimer:
_this is a quick and dirty experiment, you will not find rigorous measurements, statistics and whatever, but the figures suggest that there is something that one may want to investigate further._

# tl;dr:
first few pushbacks into a vector without calling `reserve()` are relatively expensive, these changes offset this cost by using arrays of temporarily stored first few parsed JSON array elements.

# The gist
The type `ArrayElements` crudely models what some people call a "static vector", i.e. a vector-like container with capacity fixed at compile time and storage allocated inside the instance itself.

A proper "static vector" would allow to skip construction and destruction of "unused" elements so I believe it will allow to gain a little bit more speed by accomodating more elements.

With current code 4 elements seems to be the sweet spot where allocation, and construction/destruction of the elements in the array and moving them balances out.

# Crude measurements
I crudely measured performance difference with the current main branch.
I used the latest **MSVC** and **clang-cl** (that comes with MSVS) because that's what I had immediately available.
I built **tao-json-perf-parse_file.exe** executable (in RelWithDebInfo mode, but that shouldn't make a difference) and started it with JSON files from **tests** directory.

The figures are the timings "per iteration" from the benchmark output in milliseconds.

<table>
<thead>
  <tr>
    <th rowspan="2"></th>
    <th colspan="3">MSVC</th>
    <th colspan="3">clang-cl</th>
  </tr>
  <tr>
    <th>base</th>
    <th>changed</th>
    <th>diff</th>
    <th>base</th>
    <th>changed</th>
    <th>diff</th>
  </tr>
</thead>
<tbody>
  <tr>
    <td>canada.json</td>
    <td>43</td>
    <td>39</td>
    <td>-9%</td>
    <td>35</td>
    <td>31</td>
    <td>-11%</td>
  </tr>
  <tr>
    <td>citm_catalog.json</td>
    <td>23</td>
    <td>21</td>
    <td>-9%</td>
    <td>21</td>
    <td>18</td>
    <td>-14%</td>
  </tr>
  <tr>
    <td>twitter.json</td>
    <td>8,5</td>
    <td>8</td>
    <td>-6%</td>
    <td>8</td>
    <td>7</td>
    <td>-13%</td>
  </tr>
  <tr>
    <td>blns.json</td>
    <td>0,2</td>
    <td>0,2</td>
    <td>0%</td>
    <td>0,18</td>
    <td>0,16</td>
    <td>-11%</td>
  </tr>
</tbody>
</table>

The measurements were quite consistent across few runs.
The parsed JSON files were on a relatively fast SSD so file reading speed should not have had a large influence.
I couldn't use **clang** (without "-cl") driver because of warnings that were treated as errors.
<details><summary>Click/tap to show</summary>

```
>------ Build started: Project: CMakeLists, Configuration: RelWithDebInfo ------
  [1/2] Building CXX object src/perf/json/CMakeFiles/tao-json-perf-parse_file.dir/parse_file.cpp.obj
  FAILED: src/perf/json/CMakeFiles/tao-json-perf-parse_file.dir/parse_file.cpp.obj 
  C:\PROGRA~1\MIB055~1\2022\COMMUN~1\VC\Tools\Llvm\x64\bin\CLANG_~1.EXE  -ID:/dev/taojson/include -ID:/dev/taojson/external/PEGTL/include --target=amd64-pc-windows-msvc -fdiagnostics-absolute-paths -O2 -DNDEBUG -g -Xclang -gcodeview -std=c++17 -D_DLL -D_MT -Xclang --dependent-lib=msvcrt -pedantic -Wall -Wextra -Wshadow -Werror -MD -MT src/perf/json/CMakeFiles/tao-json-perf-parse_file.dir/parse_file.cpp.obj -MF src\perf\json\CMakeFiles\tao-json-perf-parse_file.dir\parse_file.cpp.obj.d -o src/perf/json/CMakeFiles/tao-json-perf-parse_file.dir/parse_file.cpp.obj -c D:/dev/taojson/src/perf/json/parse_file.cpp
  In file included from D:/dev/taojson/src/perf/json/parse_file.cpp:4:
  In file included from D:/dev/taojson/include\tao/json.hpp:11:
  In file included from D:/dev/taojson/include\tao/json/from_file.hpp:10:
  In file included from D:/dev/taojson/include\tao/json/events/from_file.hpp:9:
  In file included from D:/dev/taojson/include\tao/json/events/../internal/action.hpp:16:
  In file included from D:/dev/taojson/include\tao/json/internal/number_state.hpp:13:
D:\dev\taojson\include\tao\json\external\double.hpp(89,9): error G748BFC68: extension used [-Werror,-Wlanguage-extension-token]
  typedef __int64 int64_t;
          ^
D:\dev\taojson\include\tao\json\external\double.hpp(90,18): error G748BFC68: extension used [-Werror,-Wlanguage-extension-token]
  typedef unsigned __int64 uint64_t;
  
                   ^
  
  2 errors generated.
  
  ninja: build stopped: subcommand failed.

Build failed.
```
</details>

To be at least a little bit conservative I rounded measurements of **base** implementation down-ish (overestimated) and that of **changed** implementation up-ish (underestimated).

# Conclusion
All in all I would say that you would want to investigate this idea of speedup. It seems to not hurt where it is not used, e.g when JSON does not contain (a lot of) arrays, and on the other hand even _this crude_ implementation gives noticeable speedup.

I do not plan to develop fully fledged implementation of this idea in this library.
Please feel free to use this code as is or as a starting point.