### PR TITLE
Fix clang format reports

### DIFF
--- a/include/tao/json/basic_value.hpp
+++ b/include/tao/json/basic_value.hpp
@@ -156,7 +156,7 @@ namespace tao::json
          return v;
       }
 
-      basic_value& operator=( basic_value v ) noexcept( std::is_nothrow_move_assignable_v< variant_t > && std::is_nothrow_move_assignable_v< public_base_t > )
+      basic_value& operator=( basic_value v ) noexcept( std::is_nothrow_move_assignable_v< variant_t >&& std::is_nothrow_move_assignable_v< public_base_t > )
       {
          m_variant = std::move( v.m_variant );
          public_base_t::operator=( static_cast< public_base_t&& >( v ) );

--- a/src/test/json/make_events.hpp
+++ b/src/test/json/make_events.hpp
@@ -234,8 +234,10 @@ namespace tao::json::test
       }
       {
          // TODO: More numbers...
+         // clang-format off
       }
       {
+         // clang-format on
          c.string( "" );
          c.element();
       }


### PR DESCRIPTION
- one about a block statement that clang-format want to erroneously wrap with an empty one;
- one about an extra space.
