### PR TITLE
fix new clang -Wdeprecated-literal-operator (no whitespace between ""…

### DIFF
--- a/include/tao/json/binary.hpp
+++ b/include/tao/json/binary.hpp
@@ -19,9 +19,9 @@ namespace tao::json
 {
    namespace internal
    {
-      [[nodiscard]] constexpr char unhex_char( const char c ) noexcept
+      [[nodiscard]] constexpr char unhex_char(const char c) noexcept
       {
-         return static_cast< char >( ( c < 'A' ) ? ( c - '0' ) : ( ( c < 'a' ) ? ( c - 'A' + 10 ) : ( c - 'a' + 10 ) ) );
+         return static_cast<char>((c < 'A') ? (c - '0') : ((c < 'a') ? (c - 'A' + 10) : (c - 'a' + 10)));
       }
 
       template< typename V, V... >
@@ -43,7 +43,7 @@ namespace tao::json
       struct unhex_helper< T, vlist< V, Vs... >, C >
          : unhex_helper< T, vlist< V > >
       {
-         static_assert( internal::dependent_false< T >, "digits must occur in pairs" );
+         static_assert(internal::dependent_false< T >, "digits must occur in pairs");
       };
 
       template< typename T, typename V, V... Vs, char C1, char... Cs >
@@ -56,27 +56,27 @@ namespace tao::json
       struct unhex_helper< T, vlist< V, Vs... >, C0, '\'', Cs... >
          : unhex_helper< T, vlist< V > >
       {
-         static_assert( internal::dependent_false< T >, "digit separator only allowed between pairs of digits" );
+         static_assert(internal::dependent_false< T >, "digit separator only allowed between pairs of digits");
       };
 
       template< typename T, typename V, V... Vs, char C0, char C1, char... Cs >
       struct unhex_helper< T, vlist< V, Vs... >, C0, C1, Cs... >
-         : unhex_helper< T, vlist< V, Vs..., V( ( unhex_char( C0 ) << 4 ) + unhex_char( C1 ) ) >, Cs... >
+         : unhex_helper< T, vlist< V, Vs..., V((unhex_char(C0) << 4) + unhex_char(C1)) >, Cs... >
       {
       };
 
       template< typename T, typename V, char C >
       [[nodiscard]] constexpr T unhex()
       {
-         static_assert( internal::dependent_false< T >, "not a hex literal" );
+         static_assert(internal::dependent_false< T >, "not a hex literal");
          return T{};
       }
 
       template< typename T, typename V, char C0, char C1, char... Cs >
       [[nodiscard]] constexpr T unhex()
       {
-         static_assert( C0 == '0', "not a hex literal" );
-         static_assert( C1 == 'x' || C1 == 'X', "not a hex literal" );
+         static_assert(C0 == '0', "not a hex literal");
+         static_assert(C1 == 'x' || C1 == 'X', "not a hex literal");
          return unhex_helper< T, vlist< V >, Cs... >::unhex();
       }
 
@@ -91,7 +91,7 @@ namespace tao::json
    inline namespace literals
    {
       template< char... Cs >
-      [[nodiscard]] std::vector< std::byte > operator"" _binary()
+      [[nodiscard]] std::vector< std::byte > operator""_binary()
       {
          return internal::unhex< std::vector< std::byte >, Cs... >();
       }

--- a/include/tao/json/from_string.hpp
+++ b/include/tao/json/from_string.hpp
@@ -14,24 +14,24 @@
 namespace tao::json
 {
    template< template< typename... > class Traits, template< typename... > class... Transformers, typename... Ts >
-   [[nodiscard]] basic_value< Traits > basic_from_string( Ts&&... ts )
+   [[nodiscard]] basic_value< Traits > basic_from_string(Ts&&... ts)
    {
       events::transformer< events::to_basic_value< Traits >, Transformers... > consumer;
-      events::from_string( consumer, std::forward< Ts >( ts )... );
-      return std::move( consumer.value );
+      events::from_string(consumer, std::forward< Ts >(ts)...);
+      return std::move(consumer.value);
    }
 
    template< template< typename... > class... Transformers, typename... Ts >
-   [[nodiscard]] value from_string( Ts&&... ts )
+   [[nodiscard]] value from_string(Ts&&... ts)
    {
-      return basic_from_string< traits, Transformers... >( std::forward< Ts >( ts )... );
+      return basic_from_string< traits, Transformers... >(std::forward< Ts >(ts)...);
    }
 
    inline namespace literals
    {
-      [[nodiscard]] inline value operator"" _json( const char* data, const std::size_t size )
+      [[nodiscard]] inline value operator""_json(const char* data, const std::size_t size)
       {
-         return json::from_string( data, size, "literal" );
+         return json::from_string(data, size, "literal");
       }
 
    }  // namespace literals

--- a/include/tao/json/jaxn/from_string.hpp
+++ b/include/tao/json/jaxn/from_string.hpp
@@ -15,24 +15,24 @@
 namespace tao::json::jaxn
 {
    template< template< typename... > class Traits, template< typename... > class... Transformers, typename... Ts >
-   [[nodiscard]] basic_value< Traits > basic_from_string( Ts&&... ts )
+   [[nodiscard]] basic_value< Traits > basic_from_string(Ts&&... ts)
    {
       json::events::transformer< json::events::to_basic_value< Traits >, Transformers... > consumer;
-      events::from_string( consumer, std::forward< Ts >( ts )... );
-      return std::move( consumer.value );
+      events::from_string(consumer, std::forward< Ts >(ts)...);
+      return std::move(consumer.value);
    }
 
    template< template< typename... > class... Transformers, typename... Ts >
-   [[nodiscard]] value from_string( Ts&&... ts )
+   [[nodiscard]] value from_string(Ts&&... ts)
    {
-      return basic_from_string< traits, Transformers... >( std::forward< Ts >( ts )... );
+      return basic_from_string< traits, Transformers... >(std::forward< Ts >(ts)...);
    }
 
    inline namespace literals
    {
-      [[nodiscard]] inline value operator"" _jaxn( const char* data, const std::size_t size )
+      [[nodiscard]] inline value operator""_jaxn(const char* data, const std::size_t size)
       {
-         return jaxn::from_string( data, size, "literal" );
+         return jaxn::from_string(data, size, "literal");
       }
 
    }  // namespace literals

--- a/include/tao/json/pointer.hpp
+++ b/include/tao/json/pointer.hpp
@@ -26,21 +26,21 @@ namespace tao::json
 {
    namespace internal
    {
-      template< std::size_t = sizeof( std::size_t ) >
+      template< std::size_t = sizeof(std::size_t) >
       struct token_to_index;
 
       template<>
       struct token_to_index< 4 >
       {
-         [[nodiscard]] static std::size_t convert( const std::string& key ) noexcept
+         [[nodiscard]] static std::size_t convert(const std::string& key) noexcept
          {
-            if( !key.empty() && key.size() <= 10 ) {
-               if( key == "0" ) {
+            if (!key.empty() && key.size() <= 10) {
+               if (key == "0") {
                   return 0;
                }
-               if( ( key[ 0 ] != '0' ) && ( key.find_first_not_of( "0123456789" ) == std::string::npos ) ) {
-                  if( key.size() < 10 || key < "4294967296" ) {
-                     return static_cast< std::size_t >( std::stoul( key ) );
+               if ((key[0] != '0') && (key.find_first_not_of("0123456789") == std::string::npos)) {
+                  if (key.size() < 10 || key < "4294967296") {
+                     return static_cast<std::size_t>(std::stoul(key));
                   }
                }
             }
@@ -51,15 +51,15 @@ namespace tao::json
       template<>
       struct token_to_index< 8 >
       {
-         [[nodiscard]] static std::size_t convert( const std::string& key ) noexcept
+         [[nodiscard]] static std::size_t convert(const std::string& key) noexcept
          {
-            if( !key.empty() && key.size() <= 20 ) {
-               if( key == "0" ) {
+            if (!key.empty() && key.size() <= 20) {
+               if (key == "0") {
                   return 0;
                }
-               if( ( key[ 0 ] != '0' ) && ( key.find_first_not_of( "0123456789" ) == std::string::npos ) ) {
-                  if( key.size() < 20 || key < "18446744073709551616" ) {
-                     return static_cast< std::size_t >( std::stoull( key ) );
+               if ((key[0] != '0') && (key.find_first_not_of("0123456789") == std::string::npos)) {
+                  if (key.size() < 20 || key < "18446744073709551616") {
+                     return static_cast<std::size_t>(std::stoull(key));
                   }
                }
             }
@@ -77,34 +77,38 @@ namespace tao::json
       std::string m_key;
 
    public:
-      explicit token( const std::string& in_key )
-         : m_index( internal::token_to_index<>::convert( in_key ) ),
-           m_key( in_key )
-      {}
+      explicit token(const std::string& in_key)
+         : m_index(internal::token_to_index<>::convert(in_key)),
+         m_key(in_key)
+      {
+      }
 
-      explicit token( std::string&& in_key ) noexcept
-         : m_index( internal::token_to_index<>::convert( in_key ) ),
-           m_key( std::move( in_key ) )
-      {}
+      explicit token(std::string&& in_key) noexcept
+         : m_index(internal::token_to_index<>::convert(in_key)),
+         m_key(std::move(in_key))
+      {
+      }
 
-      explicit token( const std::size_t in_index )
-         : m_index( in_index ),
-           m_key( std::to_string( m_index ) )
-      {}
+      explicit token(const std::size_t in_index)
+         : m_index(in_index),
+         m_key(std::to_string(m_index))
+      {
+      }
 
-      token( const token& ) = default;
-      token( token&& v ) noexcept
-         : m_index( v.m_index ),
-           m_key( std::move( v.m_key ) )
-      {}
+      token(const token&) = default;
+      token(token&& v) noexcept
+         : m_index(v.m_index),
+         m_key(std::move(v.m_key))
+      {
+      }
 
       ~token() = default;
 
-      token& operator=( const token& ) = default;
-      token& operator=( token&& v ) noexcept
+      token& operator=(const token&) = default;
+      token& operator=(token&& v) noexcept
       {
          m_index = v.m_index;
-         m_key = std::move( v.m_key );
+         m_key = std::move(v.m_key);
          return *this;
       }
 
@@ -120,18 +124,18 @@ namespace tao::json
 
       [[nodiscard]] std::size_t index() const
       {
-         if( !has_index() ) {
-            throw std::invalid_argument( internal::format( "unable to resolve json pointer with array, token '", m_key, "' is not an index" ) );
+         if (!has_index()) {
+            throw std::invalid_argument(internal::format("unable to resolve json pointer with array, token '", m_key, "' is not an index"));
          }
          return m_index;
       }
 
-      [[nodiscard]] friend bool operator==( const token& lhs, const token& rhs ) noexcept
+      [[nodiscard]] friend bool operator==(const token& lhs, const token& rhs) noexcept
       {
          return lhs.m_key == rhs.m_key;
       }
 
-      [[nodiscard]] friend bool operator<( const token& lhs, const token& rhs ) noexcept
+      [[nodiscard]] friend bool operator<(const token& lhs, const token& rhs) noexcept
       {
          return lhs.m_key < rhs.m_key;
       }
@@ -155,12 +159,13 @@ namespace tao::json
       template< typename Rule >
       struct pointer_action
          : pegtl::nothing< Rule >
-      {};
+      {
+      };
 
       template<>
       struct pointer_action< pointer_zero >
       {
-         static void apply0( std::vector< token >& /*unused*/, std::string& t )
+         static void apply0(std::vector< token >& /*unused*/, std::string& t)
          {
             t += '~';
          }
@@ -169,7 +174,7 @@ namespace tao::json
       template<>
       struct pointer_action< pointer_one >
       {
-         static void apply0( std::vector< token >& /*unused*/, std::string& t )
+         static void apply0(std::vector< token >& /*unused*/, std::string& t)
          {
             t += '/';
          }
@@ -179,18 +184,18 @@ namespace tao::json
       struct pointer_action< pointer_char >
       {
          template< typename Input >
-         static void apply( const Input& in, std::vector< token >& /*unused*/, std::string& t )
+         static void apply(const Input& in, std::vector< token >& /*unused*/, std::string& t)
          {
-            t.append( in.begin(), in.size() );
+            t.append(in.begin(), in.size());
          }
       };
 
       template<>
       struct pointer_action< pointer_token >
       {
-         static void apply0( std::vector< token >& v, std::string& t )
+         static void apply0(std::vector< token >& v, std::string& t)
          {
-            v.emplace_back( std::move( t ) );
+            v.emplace_back(std::move(t));
             t.clear();
          }
       };
@@ -201,40 +206,41 @@ namespace tao::json
       : public std::vector< token >
    {
    private:
-      void parse( const std::string& v )
+      void parse(const std::string& v)
       {
          std::string t;
-         pegtl::memory_input< pegtl::tracking_mode::lazy, pegtl::eol::lf_crlf, const char* > in( v, "parse()" );
-         pegtl::parse< internal::pointer_grammar, internal::pointer_action >( in, vector(), t );
+         pegtl::memory_input< pegtl::tracking_mode::lazy, pegtl::eol::lf_crlf, const char* > in(v, "parse()");
+         pegtl::parse< internal::pointer_grammar, internal::pointer_action >(in, vector(), t);
       }
 
    public:
       pointer() = default;
-      pointer( const pointer& ) = default;
-      pointer( pointer&& p ) = default;
+      pointer(const pointer&) = default;
+      pointer(pointer&& p) = default;
 
-      explicit pointer( const std::string& v )
+      explicit pointer(const std::string& v)
       {
-         parse( v );
+         parse(v);
       }
 
-      pointer( const std::initializer_list< token >& l )
-         : std::vector< token >( l )
-      {}
+      pointer(const std::initializer_list< token >& l)
+         : std::vector< token >(l)
+      {
+      }
 
       ~pointer() = default;
 
-      pointer& operator=( const pointer& ) = default;
-      pointer& operator=( pointer&& p ) = default;
+      pointer& operator=(const pointer&) = default;
+      pointer& operator=(pointer&& p) = default;
 
-      pointer& operator=( const std::string& v )
+      pointer& operator=(const std::string& v)
       {
          clear();
-         parse( v );
+         parse(v);
          return *this;
       }
 
-      pointer& operator=( const std::initializer_list< token >& l )
+      pointer& operator=(const std::initializer_list< token >& l)
       {
          vector() = l;
          return *this;
@@ -249,115 +255,115 @@ namespace tao::json
 
       void pop_back()
       {
-         assert( !empty() );
+         assert(!empty());
          vector().pop_back();
       }
 
-      [[nodiscard]] bool is_prefix_of( const pointer& other ) const noexcept
+      [[nodiscard]] bool is_prefix_of(const pointer& other) const noexcept
       {
-         if( other.size() >= size() ) {
-            return std::equal( begin(), end(), other.begin() );
+         if (other.size() >= size()) {
+            return std::equal(begin(), end(), other.begin());
          }
          return false;
       }
 
       [[nodiscard]] std::vector< token >& vector() noexcept
       {
-         return static_cast< std::vector< token >& >( *this );
+         return static_cast<std::vector< token >&>(*this);
       }
 
       [[nodiscard]] const std::vector< token >& vector() const noexcept
       {
-         return static_cast< const std::vector< token >& >( *this );
+         return static_cast<const std::vector< token >&>(*this);
       }
    };
 
-   [[nodiscard]] inline bool operator==( const pointer& lhs, const pointer& rhs ) noexcept
+   [[nodiscard]] inline bool operator==(const pointer& lhs, const pointer& rhs) noexcept
    {
       return lhs.vector() == rhs.vector();
    }
 
-   [[nodiscard]] inline bool operator<( const pointer& lhs, const pointer& rhs ) noexcept
+   [[nodiscard]] inline bool operator<(const pointer& lhs, const pointer& rhs) noexcept
    {
       return lhs.vector() < rhs.vector();
    }
 
-   [[nodiscard]] inline bool operator!=( const pointer& lhs, const pointer& rhs ) noexcept
+   [[nodiscard]] inline bool operator!=(const pointer& lhs, const pointer& rhs) noexcept
    {
-      return !( lhs == rhs );
+      return !(lhs == rhs);
    }
 
-   [[nodiscard]] inline bool operator>( const pointer& lhs, const pointer& rhs ) noexcept
+   [[nodiscard]] inline bool operator>(const pointer& lhs, const pointer& rhs) noexcept
    {
       return rhs < lhs;
    }
 
-   [[nodiscard]] inline bool operator<=( const pointer& lhs, const pointer& rhs ) noexcept
+   [[nodiscard]] inline bool operator<=(const pointer& lhs, const pointer& rhs) noexcept
    {
-      return !( rhs < lhs );
+      return !(rhs < lhs);
    }
 
-   [[nodiscard]] inline bool operator>=( const pointer& lhs, const pointer& rhs ) noexcept
+   [[nodiscard]] inline bool operator>=(const pointer& lhs, const pointer& rhs) noexcept
    {
-      return !( lhs < rhs );
+      return !(lhs < rhs);
    }
 
-   inline pointer& operator+=( pointer& lhs, const std::string& rhs )
+   inline pointer& operator+=(pointer& lhs, const std::string& rhs)
    {
-      lhs.emplace_back( rhs );
+      lhs.emplace_back(rhs);
       return lhs;
    }
 
-   inline pointer& operator+=( pointer& lhs, std::string&& rhs )
+   inline pointer& operator+=(pointer& lhs, std::string&& rhs)
    {
-      lhs.emplace_back( std::move( rhs ) );
+      lhs.emplace_back(std::move(rhs));
       return lhs;
    }
 
-   inline pointer& operator+=( pointer& lhs, const std::size_t rhs )
+   inline pointer& operator+=(pointer& lhs, const std::size_t rhs)
    {
-      lhs.emplace_back( rhs );
+      lhs.emplace_back(rhs);
       return lhs;
    }
 
-   [[nodiscard]] inline pointer operator+( const pointer& p, const std::string& v )
+   [[nodiscard]] inline pointer operator+(const pointer& p, const std::string& v)
    {
-      pointer nrv( p );
+      pointer nrv(p);
       nrv += v;
       return nrv;
    }
 
-   [[nodiscard]] inline pointer operator+( const pointer& p, std::string&& v )
+   [[nodiscard]] inline pointer operator+(const pointer& p, std::string&& v)
    {
-      pointer nrv( p );
-      nrv += std::move( v );
+      pointer nrv(p);
+      nrv += std::move(v);
       return nrv;
    }
 
-   [[nodiscard]] inline pointer operator+( const pointer& p, const std::size_t i )
+   [[nodiscard]] inline pointer operator+(const pointer& p, const std::size_t i)
    {
-      pointer nrv( p );
+      pointer nrv(p);
       nrv += i;
       return nrv;
    }
 
    namespace internal
    {
-      [[nodiscard]] inline std::string tokens_to_string( std::vector< token >::const_iterator it, const std::vector< token >::const_iterator& end )
+      [[nodiscard]] inline std::string tokens_to_string(std::vector< token >::const_iterator it, const std::vector< token >::const_iterator& end)
       {
          std::string result;
-         while( it != end ) {
+         while (it != end) {
             result += '/';
-            for( const char c : it->key() ) {
-               switch( c ) {
-                  case '~':
-                     result += "~0";
-                     break;
-                  case '/':
-                     result += "~1";
-                     break;
-                  default:
-                     result += c;
+            for (const char c : it->key()) {
+               switch (c) {
+               case '~':
+                  result += "~0";
+                  break;
+               case '/':
+                  result += "~1";
+                  break;
+               default:
+                  result += c;
                }
             }
             ++it;
@@ -365,42 +371,42 @@ namespace tao::json
          return result;
       }
 
-      [[nodiscard]] inline std::runtime_error invalid_type( const std::vector< token >::const_iterator& begin, const std::vector< token >::const_iterator& end )
+      [[nodiscard]] inline std::runtime_error invalid_type(const std::vector< token >::const_iterator& begin, const std::vector< token >::const_iterator& end)
       {
-         return std::runtime_error( internal::format( "unable to resolve JSON Pointer '", tokens_to_string( begin, end ), "' -- value type is neither 'object' nor 'array'" ) );
+         return std::runtime_error(internal::format("unable to resolve JSON Pointer '", tokens_to_string(begin, end), "' -- value type is neither 'object' nor 'array'"));
       }
 
       template< typename T >
-      [[nodiscard]] T& pointer_at( T* v, const std::vector< token >::const_iterator& begin, const std::vector< token >::const_iterator& end )
+      [[nodiscard]] T& pointer_at(T* v, const std::vector< token >::const_iterator& begin, const std::vector< token >::const_iterator& end)
       {
-         for( auto it = begin; it != end; ++it ) {
-            switch( v->type() ) {
-               case type::ARRAY:
-                  v = &v->at( it->index() );
-                  break;
-               case type::OBJECT:
-                  v = &v->at( it->key() );
-                  break;
-               default:
-                  throw invalid_type( begin, std::next( it ) );
+         for (auto it = begin; it != end; ++it) {
+            switch (v->type()) {
+            case type::ARRAY:
+               v = &v->at(it->index());
+               break;
+            case type::OBJECT:
+               v = &v->at(it->key());
+               break;
+            default:
+               throw invalid_type(begin, std::next(it));
             }
          }
          return *v;
       }
 
       template< typename T >
-      [[nodiscard]] T* pointer_find( T* v, const std::vector< token >::const_iterator& begin, const std::vector< token >::const_iterator& end )
+      [[nodiscard]] T* pointer_find(T* v, const std::vector< token >::const_iterator& begin, const std::vector< token >::const_iterator& end)
       {
-         for( auto it = begin; v && ( it != end ); ++it ) {
-            switch( v->type() ) {
-               case type::ARRAY:
-                  v = v->find( it->index() );
-                  break;
-               case type::OBJECT:
-                  v = v->find( it->key() );
-                  break;
-               default:
-                  throw invalid_type( begin, std::next( it ) );
+         for (auto it = begin; v && (it != end); ++it) {
+            switch (v->type()) {
+            case type::ARRAY:
+               v = v->find(it->index());
+               break;
+            case type::OBJECT:
+               v = v->find(it->key());
+               break;
+            default:
+               throw invalid_type(begin, std::next(it));
             }
          }
          return v;
@@ -408,26 +414,26 @@ namespace tao::json
 
    }  // namespace internal
 
-   [[nodiscard]] inline std::string to_string( const pointer& p )
+   [[nodiscard]] inline std::string to_string(const pointer& p)
    {
-      return internal::tokens_to_string( p.begin(), p.end() );
+      return internal::tokens_to_string(p.begin(), p.end());
    }
 
-   [[nodiscard]] inline std::string to_string( pointer& p )
+   [[nodiscard]] inline std::string to_string(pointer& p)
    {
-      return internal::tokens_to_string( p.begin(), p.end() );
+      return internal::tokens_to_string(p.begin(), p.end());
    }
 
-   [[nodiscard]] inline std::string to_string( pointer&& p )
+   [[nodiscard]] inline std::string to_string(pointer&& p)
    {
-      return internal::tokens_to_string( p.begin(), p.end() );
+      return internal::tokens_to_string(p.begin(), p.end());
    }
 
    inline namespace literals
    {
-      [[nodiscard]] inline pointer operator"" _json_pointer( const char* data, const std::size_t size )
+      [[nodiscard]] inline pointer operator""_json_pointer(const char* data, const std::size_t size)
       {
-         return pointer( { data, size } );
+         return pointer({ data, size });
       }
 
    }  // namespace literals


### PR DESCRIPTION
New Clang 20 compiler warning: -Wdeprecated-literal-operator 

Generate warning (and with -Werror errors) like:

```bash
/home/sven/src/json/include/tao/json/binary.hpp:94:57: error: identifier '_binary' preceded by whitespace in a literal operator declaration is deprecated [-Werror,-Wdeprecated-literal-operator]
   94 |       [[nodiscard]] std::vector< std::byte > operator"" _binary()
      |                                              ~~~~~~~~~~~^~~~~~~
      |                                              operator""_binary
```
